### PR TITLE
Add Sprunki menu link and Zoo 3D Cube page

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
                 <a href="#games">全部游戏</a>
                 <a href="https://scratch.mit.edu" target="_blank" rel="noopener">Scratch 官网</a>
                 <a href="game-detail.html?id=paper-minecraft">热门推荐</a>
+                <a href="sprunki.html">Sprunki 专区</a>
             </nav>
         </div>
     </header>

--- a/sprunki.html
+++ b/sprunki.html
@@ -11,6 +11,8 @@
     .game-embed iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; }
     .sprunki-page { max-width: 1200px; margin: 0 auto; padding: 2rem 1rem 4rem; }
     .sprunki-page h1 { margin-bottom: 1.5rem; text-align: center; }
+    .sprunki-intro { margin: 0 auto 2.5rem; max-width: 860px; text-align: left; line-height: 1.75; color: #334155; }
+    .sprunki-intro h2 { font-size: 1.5rem; margin-bottom: 1rem; text-align: center; color: #0f172a; }
     .embed-grid { display: grid; gap: 2rem; }
     @media (min-width: 768px) {
       .embed-grid { grid-template-columns: repeat(2, 1fr); }
@@ -27,12 +29,18 @@
       <nav class="site-nav" aria-label="主要导航">
         <a href="index.html">首页</a>
         <a href="game-detail.html?id=sprunki">Sprunki 详情</a>
+        <a href="zoo-3dcube.html">Zoo 3D Cube</a>
       </nav>
     </div>
   </header>
 
   <main class="sprunki-page">
     <h1>Sprunki 在线试玩专区</h1>
+    <section class="sprunki-intro" aria-labelledby="sprunki-intro-heading">
+      <h2 id="sprunki-intro-heading">游戏介绍</h2>
+      <p>Sprunki 将节奏、解谜与即兴创作巧妙结合，玩家需要在充满未知的音轨中不断尝试，寻找正确的节奏组合，让角色顺利通关。与传统音游不同，Sprunki 不限制你必须照搬谱面，而是鼓励在探索中不断实验，感受音乐与互动之间的奇妙火花。</p>
+      <p>在本页面，你可以体验多个来源的 Sprunki 在线版本，包括桌面端的高清嵌入和适配移动设备的自适应窗口。挑选最适合你的版本，戴上耳机，跟随节奏一起沉浸在 Sprunki 的奇幻世界里。</p>
+    </section>
     <div class="embed-grid">
       <section class="iframe-wrapper" aria-label="GameFlare Sprunki">
         <iframe src="https://www.gameflare.com/embed/sprunki/" frameborder="0" scrolling="no" width="800" height="635" allowfullscreen></iframe>

--- a/zoo-3dcube.html
+++ b/zoo-3dcube.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Zoo 3D Cube 互动体验</title>
+  <meta name="description" content="Zoo 3D Cube 在线互动体验，在立方体中认识可爱的动物角色。">
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    .zoo-page { max-width: 1100px; margin: 0 auto; padding: 2rem 1rem 4rem; }
+    .zoo-page h1 { margin-bottom: 1.5rem; text-align: center; }
+    .zoo-intro { margin: 0 auto 2rem; max-width: 820px; line-height: 1.75; color: #334155; text-align: center; }
+    .iframe-shell { position: relative; width: 100%; padding-top: 62.5%; border-radius: 18px; overflow: hidden; box-shadow: 0 20px 45px rgba(15, 23, 42, 0.25); }
+    .iframe-shell iframe { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="logo" href="index.html">Shadowmilk Scratch</a>
+      <nav class="site-nav" aria-label="主要导航">
+        <a href="index.html">首页</a>
+        <a href="sprunki.html">Sprunki 专区</a>
+        <a href="game-detail.html?id=zoo-3dcube">游戏详情</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="zoo-page">
+    <h1>Zoo 3D Cube 在线互动</h1>
+    <section class="zoo-intro" aria-label="Zoo 3D Cube 介绍">
+      <p>Zoo 3D Cube 将常见动物与 3D 立方体玩具巧妙结合，通过简单的参数设置即可把猫、狗、猪、羊等角色映射到不同颜色的面上。你可以拖动、旋转立方体，从不同角度观察角色造型，同时配合色彩与背景的变化，获得轻松愉快的互动体验。</p>
+      <p>下方提供官方 Zoo.js 的在线演示版本，无需安装即可打开浏览器直接操作。推荐使用桌面浏览器获得更流畅的旋转体验，移动端同样支持多指手势缩放与旋转。</p>
+    </section>
+    <section class="iframe-shell" aria-label="Zoo 3D Cube 在线演示">
+      <iframe
+        id="zoo-3dcube"
+        src="https://zoo-js.github.io/3dcube/?red=cat&amp;white=dog&amp;blue=pig&amp;green=sheep&amp;orange=koala&amp;yellow=ant&amp;bg=*ffd8bf"
+        name="3dcube"
+        width="100%"
+        height="100%"
+        scrolling="no"
+        frameborder="0">
+      </iframe>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p>Shadowmilk Scratch Arcade · 一起守护 Scratch 的创意与乐趣</p>
+      <div class="footer-links">
+        <a href="https://scratch.mit.edu/parents" target="_blank" rel="noopener">家长指引</a>
+        <a href="https://scratch.mit.edu/community_guidelines" target="_blank" rel="noopener">社区守则</a>
+        <a href="mailto:hello@shadowmilk.org">联系站长</a>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Sprunki entry to the homepage navigation for quick access
- expand the Sprunki page with a written game overview and shared navigation links
- introduce a new Zoo 3D Cube page with the official interactive iframe embed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d62d54e5d883219e927f4b74c4e6dd