### PR TITLE
Add Zoo 3D Cube link to home navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
                 <a href="https://scratch.mit.edu" target="_blank" rel="noopener">Scratch 官网</a>
                 <a href="game-detail.html?id=paper-minecraft">热门推荐</a>
                 <a href="sprunki.html">Sprunki 专区</a>
+                <a href="zoo-3dcube.html">Zoo 3D Cube</a>
             </nav>
         </div>
     </header>


### PR DESCRIPTION
## Summary
- add a Zoo 3D Cube menu entry on the homepage header navigation so users can access the dedicated page directly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d62f618e5c8321a1759ddc99b9625e