### PR TITLE
Add XML sitemap for search engines

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://youxistudio.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://youxistudio.com/sprunki.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://youxistudio.com/zoo-3dcube.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://youxistudio.com/game-detail.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add a sitemap.xml file so that the main pages are discoverable by search engines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcf8811ec48321be8979e50cd9b3b5