### PR TITLE
Revamp homepage into icon-based game launcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,66 +13,21 @@
 </script>
 
 
-
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Shadowmilk Scratch Arcade</title>
     <meta name="description" content="Shadowmilk Scratch Arcade 为你精选优质 Scratch 游戏，直接在线畅玩，体验创意与乐趣。">
     <link rel="stylesheet" href="styles.css">
 </head>
-<body>
-    <header class="site-header">
-        <div class="container header-inner">
-            <a class="logo" href="index.html">Shadowmilk Scratch</a>
-            <nav class="site-nav" aria-label="主要导航">
-                <a href="#games">全部游戏</a>
-                <a href="https://scratch.mit.edu" target="_blank" rel="noopener">Scratch 官网</a>
-                <a href="game-detail.html?id=paper-minecraft">热门推荐</a>
-                <a href="sprunki.html">Sprunki 专区</a>
-                <a href="zoo-3dcube.html">Zoo 3D Cube</a>
-            </nav>
-        </div>
-    </header>
-
-    <main class="page" id="home">
-        <div class="container">
-            <section class="intro">
-                <p class="eyebrow">SHADOWMILK SCRATCH COLLECTION</p>
-                <h1>精选 Scratch 游戏，一站式畅玩</h1>
-                <p>我们挑选了社区里口碑与人气俱佳的 Scratch 作品，提供统一的清爽界面、操作说明与快速入口，让你像访问 takecareofshadowmilk.org/scratch 一样，轻松探索 Scratch 的无限创意。</p>
-            </section>
-
-            <section class="tools" aria-label="筛选工具">
-                <div class="search-row">
-                    <input id="searchInput" class="search-input" type="search" placeholder="搜索游戏名称或标签..." autocomplete="off" aria-label="搜索 Scratch 游戏">
-                    <p id="resultsCount" class="results-count" aria-live="polite"></p>
-                </div>
-                <div class="filter-row" role="tablist" aria-label="游戏分类">
-                    <button type="button" class="filter-button is-active" data-filter="all" role="tab" aria-selected="true">全部</button>
-                    <button type="button" class="filter-button" data-filter="adventure" role="tab" aria-selected="false">冒险</button>
-                    <button type="button" class="filter-button" data-filter="arcade" role="tab" aria-selected="false">街机</button>
-                    <button type="button" class="filter-button" data-filter="platformer" role="tab" aria-selected="false">平台跳跃</button>
-                    <button type="button" class="filter-button" data-filter="puzzle" role="tab" aria-selected="false">益智</button>
-                    <button type="button" class="filter-button" data-filter="creative" role="tab" aria-selected="false">创意</button>
-                </div>
-            </section>
-
-            <section class="games" id="games" aria-live="polite">
-                <div class="games-grid" id="gamesGrid"></div>
-            </section>
-        </div>
+<body class="home-landing">
+    <main class="home-launcher" aria-labelledby="homeHeading">
+        <header class="home-launcher__header">
+            <p class="home-launcher__eyebrow">SHADOWMILK SCRATCH COLLECTION</p>
+            <h1 id="homeHeading">选择一款游戏立即开玩</h1>
+            <p class="home-launcher__description">点击任意图标即可进入游戏详情并开始游玩，我们会持续更新最新、最好玩的 Scratch 作品。</p>
+        </header>
+        <section class="icon-wall" id="gamesGrid" aria-label="精选 Scratch 游戏列表"></section>
     </main>
-
-    <footer class="site-footer">
-        <div class="container footer-inner">
-            <p>Shadowmilk Scratch Arcade · 一起守护 Scratch 的创意与乐趣</p>
-            <div class="footer-links">
-                <a href="https://scratch.mit.edu/parents" target="_blank" rel="noopener">家长指引</a>
-                <a href="https://scratch.mit.edu/community_guidelines" target="_blank" rel="noopener">社区守则</a>
-                <a href="mailto:hello@shadowmilk.org">联系站长</a>
-            </div>
-        </div>
-    </footer>
 
     <script src="games-data.js"></script>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,142 +1,43 @@
 (function () {
     const games = Array.isArray(window.gamesData) ? window.gamesData : [];
-    const categoryLabels = window.gameCategoryLabels || {};
-
     const grid = document.getElementById('gamesGrid');
-    const searchInput = document.getElementById('searchInput');
-    const filterButtons = document.querySelectorAll('.filter-button');
-    const resultsCount = document.getElementById('resultsCount');
 
-    if (!grid) {
+    if (!grid || !games.length) {
+        if (grid) {
+            const empty = document.createElement('p');
+            empty.className = 'icon-wall__empty';
+            empty.textContent = '暂时没有可用的游戏，稍后再来看看吧。';
+            grid.appendChild(empty);
+        }
         return;
     }
 
-    let activeCategory = 'all';
+    const fragment = document.createDocumentFragment();
 
-    function getCategoryLabel(category) {
-        return categoryLabels[category] || category || '其他';
-    }
+    games.forEach(game => {
+        const link = document.createElement('a');
+        link.className = 'game-icon';
+        link.href = `game-detail.html?id=${encodeURIComponent(game.id)}`;
+        link.setAttribute('aria-label', `${game.title}，点击开始游戏`);
 
-    function createGameCard(game) {
-        const article = document.createElement('article');
-        article.className = 'game-card';
+        const imageWrapper = document.createElement('span');
+        imageWrapper.className = 'game-icon__image';
 
-        const figure = document.createElement('figure');
         const img = document.createElement('img');
         img.src = game.thumbnail;
-        img.alt = `${game.title} 封面`; // alt text
+        img.alt = `${game.title} 游戏图标`;
         img.loading = 'lazy';
-        figure.appendChild(img);
-        article.appendChild(figure);
 
-        const body = document.createElement('div');
-        body.className = 'game-card__body';
+        imageWrapper.appendChild(img);
+        link.appendChild(imageWrapper);
 
-        const title = document.createElement('h3');
+        const title = document.createElement('span');
+        title.className = 'game-icon__title';
         title.textContent = game.title;
-        body.appendChild(title);
+        link.appendChild(title);
 
-        const description = document.createElement('p');
-        description.textContent = game.description;
-        body.appendChild(description);
+        fragment.appendChild(link);
+    });
 
-        if (Array.isArray(game.tags) && game.tags.length) {
-            const tagsWrapper = document.createElement('div');
-            tagsWrapper.className = 'game-card__tags';
-            game.tags.slice(0, 3).forEach(tag => {
-                const badge = document.createElement('span');
-                badge.className = 'badge';
-                badge.textContent = tag;
-                tagsWrapper.appendChild(badge);
-            });
-            body.appendChild(tagsWrapper);
-        }
-
-        article.appendChild(body);
-
-        const footer = document.createElement('div');
-        footer.className = 'game-card__footer';
-
-        const categoryBadge = document.createElement('span');
-        categoryBadge.className = 'badge';
-        categoryBadge.textContent = getCategoryLabel(game.category);
-        footer.appendChild(categoryBadge);
-
-        const playButton = document.createElement('button');
-        playButton.className = 'play-button';
-        playButton.type = 'button';
-        playButton.textContent = '开始游玩';
-        playButton.addEventListener('click', () => openGame(game.id));
-        footer.appendChild(playButton);
-
-        article.appendChild(footer);
-
-        article.addEventListener('click', (event) => {
-            if (event.target !== playButton) {
-                openGame(game.id);
-            }
-        });
-
-        return article;
-    }
-
-    function openGame(id) {
-        window.location.href = `game-detail.html?id=${encodeURIComponent(id)}`;
-    }
-
-    function renderGames() {
-        const query = (searchInput?.value || '').trim().toLowerCase();
-
-        const filteredGames = games.filter(game => {
-            const matchesCategory = activeCategory === 'all' || game.category === activeCategory;
-            const tokens = [game.title, game.description, ...(game.tags || [])]
-                .join(' ')
-                .toLowerCase();
-            const matchesQuery = !query || tokens.includes(query);
-            return matchesCategory && matchesQuery;
-        });
-
-        grid.innerHTML = '';
-
-        if (resultsCount) {
-            resultsCount.textContent = `共找到 ${filteredGames.length} 款 Scratch 游戏`;
-        }
-
-        if (!filteredGames.length) {
-            const empty = document.createElement('div');
-            empty.className = 'empty-state';
-            empty.textContent = '暂无符合条件的游戏，试着换个关键词或分类吧。';
-            grid.appendChild(empty);
-            return;
-        }
-
-        filteredGames.forEach(game => {
-            grid.appendChild(createGameCard(game));
-        });
-    }
-
-    if (searchInput) {
-        searchInput.addEventListener('input', renderGames);
-    }
-
-    if (filterButtons.length) {
-        filterButtons.forEach(button => {
-            button.addEventListener('click', () => {
-                const category = button.dataset.filter;
-                if (!category) return;
-
-                activeCategory = category;
-
-                filterButtons.forEach(btn => {
-                    const isActive = btn === button;
-                    btn.classList.toggle('is-active', isActive);
-                    btn.setAttribute('aria-selected', String(isActive));
-                });
-
-                renderGames();
-            });
-        });
-    }
-
-    renderGames();
+    grid.appendChild(fragment);
 })();

--- a/styles.css
+++ b/styles.css
@@ -35,6 +35,124 @@ body {
     line-height: 1.6;
 }
 
+body.home-landing {
+    background: radial-gradient(circle at top left, #c0d6ff 0%, #f5d9ff 45%, #fde6ff 100%);
+    align-items: center;
+    justify-content: center;
+    padding: 3rem 1.5rem 4rem;
+}
+
+.home-launcher {
+    width: min(1000px, 100%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2.5rem;
+}
+
+.home-launcher__header {
+    text-align: center;
+    color: #1f2937;
+    max-width: 640px;
+}
+
+.home-launcher__eyebrow {
+    margin: 0 0 0.75rem;
+    font-size: 0.82rem;
+    letter-spacing: 0.28em;
+    color: rgba(30, 58, 138, 0.55);
+}
+
+.home-launcher__header h1 {
+    margin: 0 0 0.75rem;
+    font-size: clamp(2rem, 4vw, 3rem);
+    line-height: 1.2;
+}
+
+.home-launcher__description {
+    margin: 0;
+    font-size: 1rem;
+    color: rgba(30, 41, 59, 0.75);
+}
+
+.icon-wall {
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 1.5rem;
+    justify-items: center;
+}
+
+.game-icon {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.8rem;
+    text-align: center;
+    color: #1f2937;
+    text-decoration: none;
+    transition: transform 0.2s ease;
+}
+
+.game-icon__image {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 24px;
+    padding: 0.65rem;
+    background: linear-gradient(145deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.55));
+    box-shadow: 0 18px 30px rgba(79, 70, 229, 0.18);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.game-icon__image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 18px;
+    box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.05);
+}
+
+.game-icon__title {
+    font-size: 0.92rem;
+    font-weight: 600;
+    line-height: 1.35;
+    color: rgba(15, 23, 42, 0.85);
+}
+
+.game-icon:hover {
+    transform: translateY(-6px);
+}
+
+.game-icon:hover .game-icon__image {
+    box-shadow: 0 25px 45px rgba(99, 102, 241, 0.32);
+    transform: scale(1.03);
+}
+
+.icon-wall__empty {
+    margin: 0;
+    font-size: 1.05rem;
+    color: rgba(30, 41, 59, 0.7);
+}
+
+@media (max-width: 720px) {
+    body.home-landing {
+        padding-top: 2.5rem;
+        padding-bottom: 3rem;
+    }
+
+    .icon-wall {
+        grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+        gap: 1.25rem;
+    }
+
+    .game-icon__title {
+        font-size: 0.85rem;
+    }
+}
+
 img {
     max-width: 100%;
     display: block;


### PR DESCRIPTION
## Summary
- replace the landing page layout with a centered icon wall that mirrors the requested design and removes the old filter interface
- update the home script to render clickable game tiles that deep-link to their detail pages
- add dedicated styles for the new gradient background and icon grid while keeping existing page styles intact

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e079135f4483218ef67673c04a6829