### PR TITLE
Add Scratch game scraping utility page

### DIFF
--- a/game-detail.html
+++ b/game-detail.html
@@ -16,6 +16,7 @@
                 <a href="index.html#games">返回游戏列表</a>
                 <a href="https://scratch.mit.edu" target="_blank" rel="noopener">Scratch 官网</a>
                 <a id="anotherHotLink" href="game-detail.html?id=geometry-dash">另一个热门</a>
+                <a href="scratch-scraper.html">游戏抓取</a>
             </nav>
         </div>
     </header>

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
                 <a href="game-detail.html?id=paper-minecraft">热门推荐</a>
                 <a href="sprunki.html">Sprunki 专区</a>
                 <a href="zoo-3dcube.html">Zoo 3D Cube</a>
+                <a href="scratch-scraper.html">游戏抓取</a>
             </nav>
         </div>
     </header>

--- a/scratch-scraper.html
+++ b/scratch-scraper.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Scratch 游戏抓取工具 | Shadowmilk Scratch</title>
+    <meta name="description" content="在线抓取 Scratch 社区的热门项目，快速获取游戏名称、链接、嵌入代码与封面图片地址。">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header class="site-header">
+        <div class="container header-inner">
+            <a class="logo" href="index.html">Shadowmilk Scratch</a>
+            <nav class="site-nav" aria-label="主要导航">
+                <a href="index.html#games">全部游戏</a>
+                <a href="https://scratch.mit.edu" target="_blank" rel="noopener">Scratch 官网</a>
+                <a href="game-detail.html?id=paper-minecraft">热门推荐</a>
+                <a href="sprunki.html">Sprunki 专区</a>
+                <a href="zoo-3dcube.html">Zoo 3D Cube</a>
+                <a href="scratch-scraper.html" aria-current="page">游戏抓取</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="page scraper-page">
+        <div class="container">
+            <section class="scraper-intro">
+                <p class="eyebrow">SCRATCH DATA TOOLKIT</p>
+                <h1>即时抓取 Scratch 游戏关键信息</h1>
+                <p>通过官方公开 API，一键获取 Scratch 社区的热门或最新项目。输入关键词即可提取游戏名称、项目链接、嵌入 IFrame 地址以及封面图片链接，并支持复制导出，方便整理与分享。</p>
+            </section>
+
+            <form id="scraperForm" class="scraper-form" aria-label="Scratch 游戏抓取表单">
+                <div class="field-group">
+                    <label class="field-label" for="queryInput">关键词</label>
+                    <input id="queryInput" name="query" class="field-input" type="search" placeholder="例如：platformer、minecraft 或 留空抓取全部" autocomplete="off">
+                </div>
+                <div class="field-row">
+                    <div class="field-group">
+                        <label class="field-label" for="modeSelect">排序模式</label>
+                        <select id="modeSelect" name="mode" class="field-input">
+                            <option value="trending">社区热议（trending）</option>
+                            <option value="popular">最受欢迎（popular）</option>
+                            <option value="recent">最新发布（recent）</option>
+                        </select>
+                    </div>
+                    <div class="field-group">
+                        <label class="field-label" for="limitInput">抓取数量</label>
+                        <input id="limitInput" name="limit" class="field-input" type="number" min="1" max="40" value="20">
+                    </div>
+                    <div class="field-group">
+                        <label class="field-label" for="offsetInput">起始位置</label>
+                        <input id="offsetInput" name="offset" class="field-input" type="number" min="0" value="0">
+                    </div>
+                </div>
+                <button type="submit" class="primary-button">开始抓取</button>
+            </form>
+
+            <p id="scraperStatus" class="scraper-status" aria-live="polite"></p>
+
+            <section class="scraper-results" aria-live="polite">
+                <div class="table-wrapper" role="region" aria-label="抓取结果表格" tabindex="0">
+                    <table class="results-table">
+                        <thead>
+                            <tr>
+                                <th scope="col">#</th>
+                                <th scope="col">游戏名称</th>
+                                <th scope="col">Scratch 链接</th>
+                                <th scope="col">IFrame 链接</th>
+                                <th scope="col">封面图片</th>
+                            </tr>
+                        </thead>
+                        <tbody id="resultsBody"></tbody>
+                    </table>
+                </div>
+            </section>
+
+            <p class="scraper-note">说明：数据来自 Scratch 官方公开接口 <code>api.scratch.mit.edu</code>。若需要查看更多项目，可调整抓取数量与起始位置。嵌入链接可直接用于 <code>&lt;iframe&gt;</code> 内嵌展示，封面图片为 480×360 分辨率的 PNG 文件。</p>
+        </div>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container footer-inner">
+            <p>Shadowmilk Scratch Arcade · 一起守护 Scratch 的创意与乐趣</p>
+            <div class="footer-links">
+                <a href="https://scratch.mit.edu/parents" target="_blank" rel="noopener">家长指引</a>
+                <a href="https://scratch.mit.edu/community_guidelines" target="_blank" rel="noopener">社区守则</a>
+                <a href="mailto:hello@shadowmilk.org">联系站长</a>
+            </div>
+        </div>
+    </footer>
+
+    <script src="scratch-scraper.js"></script>
+</body>
+</html>

--- a/scratch-scraper.js
+++ b/scratch-scraper.js
@@ -1,0 +1,224 @@
+const API_ENDPOINT = 'https://api.scratch.mit.edu/explore/projects';
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 40;
+
+const form = document.getElementById('scraperForm');
+const queryInput = document.getElementById('queryInput');
+const modeSelect = document.getElementById('modeSelect');
+const limitInput = document.getElementById('limitInput');
+const offsetInput = document.getElementById('offsetInput');
+const statusEl = document.getElementById('scraperStatus');
+const resultsBody = document.getElementById('resultsBody');
+
+const copyFeedbackDuration = 2000;
+
+function setStatus(message, tone = 'muted') {
+  statusEl.textContent = message;
+  statusEl.dataset.tone = tone;
+}
+
+function clampLimit(value) {
+  if (Number.isNaN(value)) return DEFAULT_LIMIT;
+  return Math.min(Math.max(value, 1), MAX_LIMIT);
+}
+
+function clampOffset(value) {
+  if (Number.isNaN(value) || value < 0) return 0;
+  return value;
+}
+
+async function copyToClipboard(text) {
+  if (!text) return false;
+
+  if (navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (error) {
+      console.warn('Clipboard API failed, fallback to execCommand.', error);
+    }
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'absolute';
+  textarea.style.left = '-9999px';
+  document.body.append(textarea);
+  textarea.select();
+
+  let succeeded = false;
+  try {
+    succeeded = document.execCommand('copy');
+  } catch (error) {
+    console.warn('execCommand copy failed.', error);
+  }
+
+  textarea.remove();
+  return succeeded;
+}
+
+function createLink(url, text = url) {
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.target = '_blank';
+  anchor.rel = 'noopener';
+  anchor.textContent = text;
+  return anchor;
+}
+
+function createCopyButton(value) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'copy-button';
+  button.dataset.copy = value;
+  button.textContent = '复制';
+  return button;
+}
+
+function renderProjects(projects, offset = 0) {
+  resultsBody.innerHTML = '';
+
+  if (!projects.length) {
+    const emptyRow = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 5;
+    cell.textContent = '未找到符合条件的 Scratch 项目。请尝试调整关键词或分页参数。';
+    emptyRow.append(cell);
+    resultsBody.append(emptyRow);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  let rowNumber = 0;
+
+  projects.forEach((project) => {
+    const rawId = project?.id;
+    if (rawId === undefined || rawId === null) {
+      return;
+    }
+
+    const id = String(rawId);
+    const title = project?.title ?? '未命名项目';
+    const username = project?.author?.username ?? 'Scratch Creator';
+
+    const projectUrl = `https://scratch.mit.edu/projects/${id}`;
+    const iframeUrl = `${projectUrl}/embed`;
+    const imageUrl = `https://cdn2.scratch.mit.edu/get_image/project/${id}_480x360.png`;
+
+    const row = document.createElement('tr');
+
+    const indexCell = document.createElement('td');
+    rowNumber += 1;
+    indexCell.textContent = String(offset + rowNumber);
+    row.append(indexCell);
+
+    const titleCell = document.createElement('td');
+    const titleLink = createLink(projectUrl, title);
+    titleLink.classList.add('project-title');
+
+    const author = document.createElement('p');
+    author.className = 'project-author';
+    author.textContent = `by ${username}`;
+
+    titleCell.append(titleLink, author);
+    row.append(titleCell);
+
+    const projectCell = document.createElement('td');
+    projectCell.className = 'mono-cell';
+    projectCell.append(createLink(projectUrl, projectUrl), createCopyButton(projectUrl));
+    row.append(projectCell);
+
+    const iframeCell = document.createElement('td');
+    iframeCell.className = 'mono-cell';
+    iframeCell.append(createLink(iframeUrl, iframeUrl), createCopyButton(`<iframe src="${iframeUrl}" allowfullscreen></iframe>`));
+    row.append(iframeCell);
+
+    const imageCell = document.createElement('td');
+    imageCell.className = 'mono-cell';
+    imageCell.append(createLink(imageUrl, imageUrl), createCopyButton(imageUrl));
+    row.append(imageCell);
+
+    fragment.append(row);
+  });
+
+  resultsBody.append(fragment);
+}
+
+async function fetchProjects(query, mode, limit, offset) {
+  const params = new URLSearchParams({
+    limit: String(limit),
+    mode,
+    offset: String(offset),
+    q: query || '*'
+  });
+
+  const response = await fetch(`${API_ENDPOINT}?${params.toString()}`, {
+    headers: {
+      Accept: 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`抓取失败：${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+async function loadProjects() {
+  const query = queryInput.value.trim();
+  const mode = modeSelect.value;
+  const limit = clampLimit(parseInt(limitInput.value, 10));
+  const offset = clampOffset(parseInt(offsetInput.value, 10));
+
+  limitInput.value = String(limit);
+  offsetInput.value = String(offset);
+
+  setStatus('正在抓取 Scratch 项目信息，请稍候...', 'loading');
+
+  try {
+    const projects = await fetchProjects(query, mode, limit, offset);
+    renderProjects(projects, offset);
+
+    if (projects.length) {
+      const rangeLabel = `${offset + 1} - ${offset + projects.length}`;
+      setStatus(`抓取完成，共获得 ${projects.length} 个项目（位置 ${rangeLabel}）。`, 'success');
+    } else {
+      setStatus('抓取完成，但没有找到相关项目。', 'muted');
+    }
+  } catch (error) {
+    console.error(error);
+    setStatus(error.message || '抓取过程中出现问题，请稍后重试。', 'error');
+    renderProjects([], offset);
+  }
+}
+
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+  loadProjects();
+});
+
+resultsBody.addEventListener('click', async (event) => {
+  const button = event.target.closest('.copy-button');
+  if (!button) return;
+
+  const { copy: value } = button.dataset;
+  const originalText = button.textContent;
+
+  button.disabled = true;
+  const success = await copyToClipboard(value);
+  button.textContent = success ? '已复制' : '复制失败';
+  button.classList.toggle('is-error', !success);
+  button.classList.toggle('is-success', success);
+
+  setTimeout(() => {
+    button.textContent = originalText;
+    button.disabled = false;
+    button.classList.remove('is-error', 'is-success');
+  }, copyFeedbackDuration);
+});
+
+window.addEventListener('DOMContentLoaded', () => {
+  loadProjects();
+});

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -20,4 +20,9 @@
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
+  <url>
+    <loc>https://youxistudio.com/scratch-scraper.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>

--- a/sprunki.html
+++ b/sprunki.html
@@ -30,6 +30,7 @@
         <a href="index.html">首页</a>
         <a href="game-detail.html?id=sprunki">Sprunki 详情</a>
         <a href="zoo-3dcube.html">Zoo 3D Cube</a>
+        <a href="scratch-scraper.html">游戏抓取</a>
       </nav>
     </div>
   </header>

--- a/styles.css
+++ b/styles.css
@@ -366,3 +366,235 @@ button {
         text-align: center;
     }
 }
+
+.primary-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.4rem;
+    border-radius: 14px;
+    border: none;
+    font-weight: 600;
+    font-size: 1rem;
+    color: #fff;
+    background: linear-gradient(135deg, #2563eb, #1d4ed8);
+    cursor: pointer;
+    box-shadow: 0 18px 35px rgba(37, 99, 235, 0.25);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.primary-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 20px 45px rgba(37, 99, 235, 0.35);
+}
+
+.primary-button:active {
+    transform: translateY(1px);
+    box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+}
+
+.scraper-page {
+    background: var(--background);
+}
+
+.scraper-intro {
+    text-align: center;
+    margin-bottom: 2.5rem;
+}
+
+.scraper-intro h1 {
+    margin-bottom: 1rem;
+}
+
+.scraper-intro p {
+    margin: 0 auto;
+    max-width: 720px;
+    color: var(--text-secondary);
+}
+
+.scraper-form {
+    display: grid;
+    gap: 1.4rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 1.75rem;
+    box-shadow: var(--shadow-soft);
+    margin-bottom: 1.5rem;
+}
+
+.field-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.2rem;
+}
+
+.field-group {
+    flex: 1 1 220px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.field-label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    letter-spacing: 0.02em;
+}
+
+.field-input {
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 0.7rem 0.9rem;
+    background: var(--surface-strong);
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.field-input:focus {
+    border-color: var(--brand);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+    background: #fff;
+}
+
+.scraper-status {
+    min-height: 1.5rem;
+    margin: 0.5rem 0 1.5rem;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    transition: color 0.2s ease;
+}
+
+.scraper-status[data-tone="loading"] {
+    color: var(--brand);
+}
+
+.scraper-status[data-tone="success"] {
+    color: #15803d;
+}
+
+.scraper-status[data-tone="error"] {
+    color: #dc2626;
+}
+
+.table-wrapper {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    overflow: auto;
+    box-shadow: var(--shadow-soft);
+}
+
+.results-table {
+    width: 100%;
+    min-width: 720px;
+    border-collapse: collapse;
+}
+
+.results-table th,
+.results-table td {
+    padding: 0.9rem 1rem;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+    vertical-align: top;
+}
+
+.results-table th {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    background: var(--surface-strong);
+}
+
+.results-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.results-table tbody tr:hover {
+    background: var(--brand-soft);
+}
+
+.project-title {
+    font-weight: 600;
+    color: var(--brand);
+}
+
+.project-author {
+    margin: 0.35rem 0 0;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.mono-cell {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+    word-break: break-all;
+    font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+}
+
+.mono-cell a {
+    color: var(--text-secondary);
+}
+
+.copy-button {
+    border: 1px solid var(--border);
+    background: #f8fafc;
+    color: var(--text-secondary);
+    border-radius: 999px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.copy-button:hover {
+    border-color: var(--brand);
+    color: var(--brand);
+    background: #fff;
+}
+
+.copy-button.is-success {
+    border-color: #16a34a;
+    color: #15803d;
+    background: rgba(22, 163, 74, 0.12);
+}
+
+.copy-button.is-error {
+    border-color: #dc2626;
+    color: #dc2626;
+    background: rgba(220, 38, 38, 0.12);
+}
+
+.scraper-note {
+    margin-top: 1.75rem;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    line-height: 1.7;
+}
+
+.scraper-note code {
+    background: rgba(15, 23, 42, 0.06);
+    padding: 0.15rem 0.4rem;
+    border-radius: 6px;
+    font-size: 0.85rem;
+}
+
+@media (max-width: 720px) {
+    .scraper-form {
+        padding: 1.4rem;
+    }
+
+    .field-row {
+        gap: 1rem;
+    }
+
+    .field-group {
+        flex: 1 1 100%;
+    }
+}
+

--- a/zoo-3dcube.html
+++ b/zoo-3dcube.html
@@ -22,6 +22,7 @@
         <a href="index.html">首页</a>
         <a href="sprunki.html">Sprunki 专区</a>
         <a href="game-detail.html?id=zoo-3dcube">游戏详情</a>
+        <a href="scratch-scraper.html">游戏抓取</a>
       </nav>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- add a dedicated Scratch 项目抓取页面并放入全站主导航，方便快速获取链接信息
- 实现前端脚本调用 Scratch 官方 Explore API，支持复制项目、嵌入与封面链接
- 扩充样式与站点地图以覆盖新的工具页面

## Testing
- npm run lint *(fails: > Couldn't find any `pages` or `app` directory. Please create one under the project root)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d84280a4832190011665b1b289d8