### PR TITLE
Add game site rankings page

### DIFF
--- a/game-detail.html
+++ b/game-detail.html
@@ -16,6 +16,7 @@
                 <a href="index.html#games">返回游戏列表</a>
                 <a href="https://scratch.mit.edu" target="_blank" rel="noopener">Scratch 官网</a>
                 <a id="anotherHotLink" href="game-detail.html?id=geometry-dash">另一个热门</a>
+                <a href="game-sites.html">游戏站榜单</a>
                 <a href="scratch-scraper.html">游戏抓取</a>
             </nav>
         </div>

--- a/game-sites.html
+++ b/game-sites.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>全球热门游戏站点榜单 | Shadowmilk Scratch</title>
+    <meta name="description" content="浏览全球热门游戏网站榜单，了解各站点的域名、定位、月访问量与特色亮点，快速找到值得收藏的游戏平台。">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header class="site-header">
+        <div class="container header-inner">
+            <a class="logo" href="index.html">Shadowmilk Scratch</a>
+            <nav class="site-nav" aria-label="主要导航">
+                <a href="index.html#games">全部游戏</a>
+                <a href="https://scratch.mit.edu" target="_blank" rel="noopener">Scratch 官网</a>
+                <a href="game-detail.html?id=paper-minecraft">热门推荐</a>
+                <a href="sprunki.html">Sprunki 专区</a>
+                <a href="zoo-3dcube.html">Zoo 3D Cube</a>
+                <a href="game-sites.html" aria-current="page">游戏站榜单</a>
+                <a href="scratch-scraper.html">游戏抓取</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="page" id="rankings">
+        <div class="container">
+            <section class="intro">
+                <p class="eyebrow">GLOBAL GAME SITE RANKINGS</p>
+                <h1>全球热门游戏站点榜单</h1>
+                <p>我们整理了覆盖资讯、评测、社区、电竞与独立游戏等维度的 10 个热门游戏网站，提供域名、站点定位、月访问量与核心特色，帮助你快速锁定最值得收藏的游戏资讯来源。</p>
+            </section>
+
+            <section class="tools" aria-label="筛选工具">
+                <div class="search-row">
+                    <input id="siteSearchInput" class="search-input" type="search" placeholder="搜索站点域名、名称或关键词..." autocomplete="off" aria-label="搜索游戏站点">
+                    <p id="siteResultsCount" class="results-count" aria-live="polite"></p>
+                </div>
+                <div class="filter-row site-filters" role="tablist" aria-label="站点类型">
+                    <button type="button" class="filter-button is-active" data-filter="all" role="tab" aria-selected="true">全部</button>
+                    <button type="button" class="filter-button" data-filter="news" role="tab" aria-selected="false">资讯</button>
+                    <button type="button" class="filter-button" data-filter="reviews" role="tab" aria-selected="false">评测</button>
+                    <button type="button" class="filter-button" data-filter="community" role="tab" aria-selected="false">社区</button>
+                    <button type="button" class="filter-button" data-filter="esports" role="tab" aria-selected="false">电竞</button>
+                    <button type="button" class="filter-button" data-filter="indie" role="tab" aria-selected="false">独立游戏</button>
+                </div>
+            </section>
+
+            <section class="rankings" aria-live="polite">
+                <div class="site-list" id="siteList"></div>
+            </section>
+        </div>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container footer-inner">
+            <p>Shadowmilk Scratch Arcade · 一起守护 Scratch 的创意与乐趣</p>
+            <div class="footer-links">
+                <a href="https://scratch.mit.edu/parents" target="_blank" rel="noopener">家长指引</a>
+                <a href="https://scratch.mit.edu/community_guidelines" target="_blank" rel="noopener">社区守则</a>
+                <a href="mailto:hello@shadowmilk.org">联系站长</a>
+            </div>
+        </div>
+    </footer>
+
+    <script src="game-sites.js"></script>
+</body>
+</html>

--- a/game-sites.js
+++ b/game-sites.js
@@ -1,0 +1,188 @@
+const siteCategories = {
+    news: "资讯",
+    reviews: "评测",
+    community: "社区",
+    esports: "电竞",
+    indie: "独立游戏"
+};
+
+const gameSites = [
+    {
+        rank: 1,
+        name: "IGN",
+        domain: "ign.com",
+        description: "全球最具影响力的游戏与娱乐媒体之一，提供实时游戏新闻、深度评测与热门视频节目。",
+        monthlyVisits: 118000000,
+        categories: ["news", "reviews"],
+        highlights: ["多语言内容", "跨平台测评", "独家采访"]
+    },
+    {
+        rank: 2,
+        name: "GameSpot",
+        domain: "gamespot.com",
+        description: "以详实的图文攻略和客观评分著称，覆盖主机、PC 与移动平台的最新大作与经典游戏。",
+        monthlyVisits: 79000000,
+        categories: ["news", "reviews"],
+        highlights: ["视频评测", "发售日历", "社区讨论"]
+    },
+    {
+        rank: 3,
+        name: "PC Gamer",
+        domain: "pcgamer.com",
+        description: "专注 PC 平台的老牌媒体，从硬件测试到独立游戏推荐，应有尽有。",
+        monthlyVisits: 56000000,
+        categories: ["news", "reviews", "indie"],
+        highlights: ["硬件指南", "Steam 优惠情报", "编辑推荐"]
+    },
+    {
+        rank: 4,
+        name: "Metacritic - Games",
+        domain: "metacritic.com/game",
+        description: "聚合全球媒体与玩家评分的权威指数，快速了解一款游戏的口碑走向。",
+        monthlyVisits: 52000000,
+        categories: ["reviews"],
+        highlights: ["综合评分", "历史数据", "榜单检索"]
+    },
+    {
+        rank: 5,
+        name: "Steam",
+        domain: "store.steampowered.com",
+        description: "全球最大的 PC 数字发行平台，拥有庞大的游戏库、创意工坊与社区功能。",
+        monthlyVisits: 450000000,
+        categories: ["community", "indie"],
+        highlights: ["创意工坊", "限时特惠", "玩家评测"]
+    },
+    {
+        rank: 6,
+        name: "Kotaku",
+        domain: "kotaku.com",
+        description: "以深入报道与文化视角闻名，关注游戏产业、玩家社区与相关亚文化。",
+        monthlyVisits: 29000000,
+        categories: ["news", "community"],
+        highlights: ["行业洞察", "专栏评论", "生活方式"]
+    },
+    {
+        rank: 7,
+        name: "Game Rant",
+        domain: "gamerant.com",
+        description: "快速掌握热门话题、更新内容与技巧攻略的资讯站，适合跟进每日热点。",
+        monthlyVisits: 41000000,
+        categories: ["news", "reviews"],
+        highlights: ["热点追踪", "攻略合集", "内容速递"]
+    },
+    {
+        rank: 8,
+        name: "MMO Champion",
+        domain: "mmo-champion.com",
+        description: "专注大型多人在线游戏的资讯社区，魔兽世界板块尤其活跃。",
+        monthlyVisits: 16000000,
+        categories: ["community", "news"],
+        highlights: ["版本前瞻", "数据挖掘", "论坛交流"]
+    },
+    {
+        rank: 9,
+        name: "Dexerto",
+        domain: "dexerto.com",
+        description: "聚焦电竞、主播与直播文化的综合媒体，覆盖英雄联盟、Valorant 等热门项目。",
+        monthlyVisits: 32000000,
+        categories: ["esports", "news"],
+        highlights: ["战队报道", "赛事解读", "主播访谈"]
+    },
+    {
+        rank: 10,
+        name: "Itch.io",
+        domain: "itch.io",
+        description: "独立开发者首选的平台，收录海量创意游戏与 Game Jam 作品，支持随心定价。",
+        monthlyVisits: 26000000,
+        categories: ["indie", "community"],
+        highlights: ["独立创作", "社区打包", "开发者工具"]
+    }
+];
+
+const siteListElement = document.getElementById('siteList');
+const siteSearchInput = document.getElementById('siteSearchInput');
+const siteResultsCount = document.getElementById('siteResultsCount');
+const filterButtons = document.querySelectorAll('.site-filters .filter-button');
+
+let activeFilter = 'all';
+
+function formatVisits(visits) {
+    if (visits >= 100000000) {
+        const formatted = (visits / 100000000).toFixed(1);
+        return `${Number(formatted)} 亿次/月`;
+    }
+    if (visits >= 10000) {
+        const formatted = (visits / 10000).toFixed(1);
+        return `${Number(formatted)} 万次/月`;
+    }
+    return `${visits.toLocaleString()} 次/月`;
+}
+
+function renderSite(site) {
+    const categoriesHtml = site.categories
+        .map((category) => `<span class="site-chip">${siteCategories[category] || category}</span>`)
+        .join('');
+
+    const highlightsHtml = site.highlights
+        .map((item) => `<li>${item}</li>`)
+        .join('');
+
+    return `
+        <article class="site-card">
+            <div class="site-rank" aria-hidden="true">#${site.rank}</div>
+            <div class="site-content">
+                <header class="site-header-row">
+                    <div>
+                        <h2 class="site-title">${site.name}</h2>
+                        <a class="site-domain" href="https://${site.domain}" target="_blank" rel="noopener">${site.domain}</a>
+                    </div>
+                    <div class="site-visits" aria-label="月访问量">${formatVisits(site.monthlyVisits)}</div>
+                </header>
+                <p class="site-description">${site.description}</p>
+                <div class="site-meta">
+                    <div class="site-tags" aria-label="站点类别">${categoriesHtml}</div>
+                    <ul class="site-highlights" aria-label="站点亮点">${highlightsHtml}</ul>
+                </div>
+            </div>
+            <a class="site-visit-button" href="https://${site.domain}" target="_blank" rel="noopener" aria-label="访问 ${site.name}">访问站点</a>
+        </article>
+    `;
+}
+
+function applyFilters() {
+    const query = siteSearchInput.value.trim().toLowerCase();
+
+    const filtered = gameSites.filter((site) => {
+        const matchesFilter = activeFilter === 'all' || site.categories.includes(activeFilter);
+        const haystack = `${site.name} ${site.domain} ${site.description} ${site.highlights.join(' ')}`.toLowerCase();
+        const matchesQuery = !query || haystack.includes(query);
+        return matchesFilter && matchesQuery;
+    });
+
+    siteListElement.innerHTML = filtered.map(renderSite).join('');
+
+    if (filtered.length === 0) {
+        siteResultsCount.textContent = '没有找到符合条件的站点。';
+    } else {
+        siteResultsCount.textContent = `共找到 ${filtered.length} 个站点。`;
+    }
+}
+
+filterButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+        if (button.dataset.filter === activeFilter) {
+            return;
+        }
+
+        activeFilter = button.dataset.filter;
+        filterButtons.forEach((btn) => {
+            btn.classList.toggle('is-active', btn === button);
+            btn.setAttribute('aria-selected', btn === button ? 'true' : 'false');
+        });
+        applyFilters();
+    });
+});
+
+siteSearchInput.addEventListener('input', applyFilters);
+
+applyFilters();

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
                 <a href="game-detail.html?id=paper-minecraft">热门推荐</a>
                 <a href="sprunki.html">Sprunki 专区</a>
                 <a href="zoo-3dcube.html">Zoo 3D Cube</a>
+                <a href="game-sites.html">游戏站榜单</a>
                 <a href="scratch-scraper.html">游戏抓取</a>
             </nav>
         </div>

--- a/scratch-scraper.html
+++ b/scratch-scraper.html
@@ -17,6 +17,7 @@
                 <a href="game-detail.html?id=paper-minecraft">热门推荐</a>
                 <a href="sprunki.html">Sprunki 专区</a>
                 <a href="zoo-3dcube.html">Zoo 3D Cube</a>
+                <a href="game-sites.html">游戏站榜单</a>
                 <a href="scratch-scraper.html" aria-current="page">游戏抓取</a>
             </nav>
         </div>

--- a/sprunki.html
+++ b/sprunki.html
@@ -30,6 +30,7 @@
         <a href="index.html">首页</a>
         <a href="game-detail.html?id=sprunki">Sprunki 详情</a>
         <a href="zoo-3dcube.html">Zoo 3D Cube</a>
+        <a href="game-sites.html">游戏站榜单</a>
         <a href="scratch-scraper.html">游戏抓取</a>
       </nav>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -106,6 +106,12 @@ button {
     transform: translateY(-1px);
 }
 
+.site-nav a[aria-current="page"] {
+    background: var(--brand-soft);
+    color: var(--brand);
+    font-weight: 600;
+}
+
 .page {
     flex: 1 0 auto;
     padding: 2.5rem 0 3.5rem;
@@ -630,3 +636,159 @@ button {
     }
 }
 
+
+.site-filters {
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.site-list {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.site-card {
+    display: grid;
+    grid-template-columns: minmax(56px, 72px) 1fr auto;
+    gap: 1.5rem;
+    align-items: stretch;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 1.5rem;
+    box-shadow: var(--shadow-soft);
+}
+
+.site-rank {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--brand);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.site-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.site-header-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.site-title {
+    margin: 0;
+    font-size: 1.25rem;
+}
+
+.site-domain {
+    color: var(--brand);
+    font-size: 0.95rem;
+    display: inline-block;
+    margin-top: 0.25rem;
+}
+
+.site-domain:hover {
+    text-decoration: underline;
+}
+
+.site-visits {
+    font-weight: 600;
+    color: var(--text-primary);
+    background: var(--surface-strong);
+    border-radius: var(--radius-sm);
+    padding: 0.4rem 0.75rem;
+    white-space: nowrap;
+}
+
+.site-description {
+    margin: 0;
+    color: var(--text-secondary);
+}
+
+.site-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.site-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.site-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.35rem 0.65rem;
+    background: var(--brand-soft);
+    color: var(--brand);
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 500;
+}
+
+.site-highlights {
+    margin: 0;
+    padding-left: 1.25rem;
+    color: var(--text-secondary);
+    display: grid;
+    gap: 0.35rem;
+}
+
+.site-visit-button {
+    align-self: center;
+    background: var(--brand);
+    color: #ffffff;
+    padding: 0.75rem 1.1rem;
+    border-radius: var(--radius-md);
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 120px;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.site-visit-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 15px 30px rgba(37, 99, 235, 0.18);
+}
+
+.site-visit-button:focus-visible {
+    outline-color: rgba(37, 99, 235, 0.4);
+}
+
+@media (max-width: 900px) {
+    .site-card {
+        grid-template-columns: auto 1fr;
+    }
+
+    .site-visit-button {
+        grid-column: 1 / -1;
+        width: 100%;
+    }
+}
+
+@media (max-width: 600px) {
+    .site-header-row {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .site-visits {
+        align-self: flex-start;
+    }
+
+    .site-rank {
+        font-size: 1.5rem;
+    }
+}

--- a/zoo-3dcube.html
+++ b/zoo-3dcube.html
@@ -22,6 +22,7 @@
         <a href="index.html">首页</a>
         <a href="sprunki.html">Sprunki 专区</a>
         <a href="game-detail.html?id=zoo-3dcube">游戏详情</a>
+        <a href="game-sites.html">游戏站榜单</a>
         <a href="scratch-scraper.html">游戏抓取</a>
       </nav>
     </div>


### PR DESCRIPTION
## Summary
- add a dedicated game site rankings page listing domains, descriptions, monthly visits, and highlights
- implement search/filter behavior and supportive styling for the ranking layout
- expose the new page across existing navigation with active-link styling

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68e1f2efb04c8321bb576eda433167d5