### PR TITLE
Add game software navigation page

### DIFF
--- a/game-detail.html
+++ b/game-detail.html
@@ -17,6 +17,7 @@
                 <a href="https://scratch.mit.edu" target="_blank" rel="noopener">Scratch 官网</a>
                 <a id="anotherHotLink" href="game-detail.html?id=geometry-dash">另一个热门</a>
                 <a href="game-sites.html">游戏站榜单</a>
+                <a href="game-navigation.html">软件导航</a>
                 <a href="scratch-scraper.html">游戏抓取</a>
             </nav>
         </div>

--- a/game-navigation.html
+++ b/game-navigation.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>游戏软件导航 | Shadowmilk Scratch</title>
+    <meta name="description" content="精选全球热门的游戏启动器、创作工具、云游戏与模拟器下载链接，快速找到适合你的游戏软件。">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header class="site-header">
+        <div class="container header-inner">
+            <a class="logo" href="index.html">Shadowmilk Scratch</a>
+            <nav class="site-nav" aria-label="主要导航">
+                <a href="index.html#games">全部游戏</a>
+                <a href="https://scratch.mit.edu" target="_blank" rel="noopener">Scratch 官网</a>
+                <a href="game-detail.html?id=paper-minecraft">热门推荐</a>
+                <a href="sprunki.html">Sprunki 专区</a>
+                <a href="zoo-3dcube.html">Zoo 3D Cube</a>
+                <a href="game-sites.html">游戏站榜单</a>
+                <a href="game-navigation.html" aria-current="page">软件导航</a>
+                <a href="scratch-scraper.html">游戏抓取</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="page" id="software-navigation">
+        <div class="container">
+            <section class="navigation-hero" aria-labelledby="navigation-hero-title">
+                <p class="eyebrow">GLOBAL GAME SOFTWARE GUIDE</p>
+                <h1 id="navigation-hero-title">游戏软件一站式导航</h1>
+                <p>从发行平台、云游戏到创作工具与模拟器，我们精选了 20+ 款值得收藏的游戏相关软件，帮助你快速找到下载入口与核心亮点。</p>
+                <div class="navigation-highlights" aria-label="导航亮点">
+                    <span>✔ 游戏发行平台</span>
+                    <span>✔ 云游戏串流</span>
+                    <span>✔ 游戏创作工具</span>
+                    <span>✔ 模拟器与辅助</span>
+                </div>
+            </section>
+
+            <section class="tools navigation-tools" aria-label="筛选与搜索">
+                <div class="search-row">
+                    <input id="softwareSearch" class="search-input" type="search" placeholder="搜索软件名称、特色或标签..." autocomplete="off" aria-label="搜索游戏软件">
+                    <p id="softwareResultsCount" class="results-count" aria-live="polite"></p>
+                </div>
+                <div class="filter-row navigation-filters" role="tablist" aria-label="软件类型">
+                    <button type="button" class="filter-button is-active" data-filter="all" role="tab" aria-selected="true">全部</button>
+                    <button type="button" class="filter-button" data-filter="platform" role="tab" aria-selected="false">发行平台</button>
+                    <button type="button" class="filter-button" data-filter="cloud" role="tab" aria-selected="false">云游戏 / 串流</button>
+                    <button type="button" class="filter-button" data-filter="creation" role="tab" aria-selected="false">创作工具</button>
+                    <button type="button" class="filter-button" data-filter="emulator" role="tab" aria-selected="false">模拟器</button>
+                    <button type="button" class="filter-button" data-filter="utility" role="tab" aria-selected="false">工具 / 管理</button>
+                </div>
+            </section>
+
+            <section class="software-section" aria-live="polite">
+                <div id="softwareGrid" class="software-grid" role="list"></div>
+            </section>
+        </div>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container footer-inner">
+            <p>Shadowmilk Scratch Arcade · 一起守护 Scratch 的创意与乐趣</p>
+            <div class="footer-links">
+                <a href="https://scratch.mit.edu/parents" target="_blank" rel="noopener">家长指引</a>
+                <a href="https://scratch.mit.edu/community_guidelines" target="_blank" rel="noopener">社区守则</a>
+                <a href="mailto:hello@shadowmilk.org">联系站长</a>
+            </div>
+        </div>
+    </footer>
+
+    <script src="game-navigation.js"></script>
+</body>
+</html>

--- a/game-navigation.js
+++ b/game-navigation.js
@@ -1,0 +1,409 @@
+const softwareData = [
+    {
+        id: 'steam',
+        name: 'Steam 客户端',
+        url: 'https://store.steampowered.com/about/',
+        category: 'platform',
+        platform: 'Windows · macOS · Linux',
+        description: 'Valve 推出的全球最大 PC 数字发行平台，支持云存档、创意工坊、社区与家庭共享。',
+        tags: ['中文界面', '成就系统', '云存档'],
+        icon: '🟦'
+    },
+    {
+        id: 'epic-games',
+        name: 'Epic Games Launcher',
+        url: 'https://store.epicgames.com/download',
+        category: 'platform',
+        platform: 'Windows · macOS',
+        description: 'Epic 官方启动器，提供每周限免、虚幻引擎工具链以及跨平台好友系统。',
+        tags: ['限时免费', '跨平台联机'],
+        icon: '🎮'
+    },
+    {
+        id: 'gog-galaxy',
+        name: 'GOG Galaxy',
+        url: 'https://www.gog.com/galaxy',
+        category: 'platform',
+        platform: 'Windows · macOS',
+        description: '无 DRM 的数字商店，整合 Steam / Epic / Xbox 等库，统一管理更新与成就。',
+        tags: ['无 DRM', '跨平台整合'],
+        icon: '🪐'
+    },
+    {
+        id: 'ubisoft-connect',
+        name: 'Ubisoft Connect',
+        url: 'https://ubisoftconnect.com',
+        category: 'platform',
+        platform: 'Windows · macOS',
+        description: '育碧官方平台，支持 Uplay+ 订阅、跨进度同步与 Ubisoft Connect 奖励。',
+        tags: ['官方商城', '跨存档'],
+        icon: '🦅'
+    },
+    {
+        id: 'ea-app',
+        name: 'EA App',
+        url: 'https://www.ea.com/ea-app',
+        category: 'platform',
+        platform: 'Windows',
+        description: 'EA 旗下 Origin 的继任者，提供 EA Play 订阅、快速更新与跨平台好友系统。',
+        tags: ['EA Play', '云同步'],
+        icon: '🟠'
+    },
+    {
+        id: 'xbox-app',
+        name: 'Xbox App for Windows',
+        url: 'https://www.xbox.com/apps/xbox-app-for-pc',
+        category: 'platform',
+        platform: 'Windows',
+        description: '微软官方应用，整合 PC Game Pass、Xbox Live 与远程游玩，支持云串流。',
+        tags: ['Game Pass', '远程游玩'],
+        icon: '🟢'
+    },
+    {
+        id: 'battlenet',
+        name: 'Battle.net',
+        url: 'https://www.blizzard.com/apps/battle.net/desktop',
+        category: 'platform',
+        platform: 'Windows · macOS',
+        description: '暴雪与动视游戏的唯一官方启动器，提供一键更新、好友系统与战网积分商城。',
+        tags: ['官方平台', '战网积分'],
+        icon: '❄️'
+    },
+    {
+        id: 'riot-client',
+        name: 'Riot Client',
+        url: 'https://www.riotgames.com/zh-cn/riot-client',
+        category: 'platform',
+        platform: 'Windows · macOS',
+        description: '拳头旗下英雄联盟、VALORANT 等作品的统一客户端，支持跨平台账号与反作弊。',
+        tags: ['英雄联盟', 'VALORANT'],
+        icon: '🛡️'
+    },
+    {
+        id: 'rockstar-launcher',
+        name: 'Rockstar Games Launcher',
+        url: 'https://zh-cn.socialclub.rockstargames.com/rockstar-games-launcher',
+        category: 'platform',
+        platform: 'Windows',
+        description: 'Rockstar 官方启动器，支持 GTA V、荒野大镖客 2 等作品的更新、云存档与 Social Club。',
+        tags: ['GTA Online', 'Social Club'],
+        icon: '⭐'
+    },
+    {
+        id: 'itch-app',
+        name: 'itch.io App',
+        url: 'https://itch.io/app',
+        category: 'platform',
+        platform: 'Windows · macOS · Linux',
+        description: '独立游戏聚合平台的桌面应用，支持离线安装、快速更新与开发者自定义渠道。',
+        tags: ['独立游戏', '离线安装'],
+        icon: '🧪'
+    },
+    {
+        id: 'playnite',
+        name: 'Playnite',
+        url: 'https://playnite.link',
+        category: 'utility',
+        platform: 'Windows',
+        description: '开源的游戏库整合工具，支持 Steam / Epic / Uplay / 模拟器一键导入与全屏客厅模式。',
+        tags: ['开源', '主题皮肤'],
+        icon: '🎨'
+    },
+    {
+        id: 'heroic-launcher',
+        name: 'Heroic Games Launcher',
+        url: 'https://heroicgameslauncher.com',
+        category: 'utility',
+        platform: 'Windows · macOS · Linux',
+        description: '开源的 Epic / GOG 第三方启动器，提供自定义 Wine、DXVK 与云存档同步。',
+        tags: ['Linux 友好', '开源'],
+        icon: '🦸'
+    },
+    {
+        id: 'discord',
+        name: 'Discord',
+        url: 'https://discord.com/download',
+        category: 'utility',
+        platform: 'Windows · macOS · Linux · iOS · Android',
+        description: '游戏玩家常用的语音与社区平台，支持高质量语音频道、活动日程与屏幕共享。',
+        tags: ['语音组队', '社区'],
+        icon: '💬'
+    },
+    {
+        id: 'parsec',
+        name: 'Parsec',
+        url: 'https://parsec.app/downloads',
+        category: 'cloud',
+        platform: 'Windows · macOS · Linux · Android',
+        description: '低延迟远程串流软件，适合远程局域网联机、云端办公或在移动端游玩 PC 游戏。',
+        tags: ['低延迟', '远程联机'],
+        icon: '⚡'
+    },
+    {
+        id: 'geforce-now',
+        name: 'GeForce NOW',
+        url: 'https://www.nvidia.cn/geforce-now/',
+        category: 'cloud',
+        platform: 'Windows · macOS · Android · ChromeOS',
+        description: 'NVIDIA 的云游戏服务，支持 RTX 光追、4K 串流以及跨设备同步进度。',
+        tags: ['云游戏', 'RTX'],
+        icon: '☁️'
+    },
+    {
+        id: 'steam-link',
+        name: 'Steam Link',
+        url: 'https://store.steampowered.com/steamlink/about',
+        category: 'cloud',
+        platform: 'Windows · iOS · Android · tvOS',
+        description: 'Valve 官方远程串流工具，将电脑上的 Steam 游戏串流到手机、平板或电视。',
+        tags: ['家庭串流', '局域网'],
+        icon: '🔗'
+    },
+    {
+        id: 'moonlight',
+        name: 'Moonlight Game Streaming',
+        url: 'https://moonlight-stream.org',
+        category: 'cloud',
+        platform: 'Windows · macOS · Linux · iOS · Android',
+        description: '开源的 NVIDIA GameStream 客户端，支持 4K60 串流、手柄直通与多种平台。',
+        tags: ['开源', '手柄直通'],
+        icon: '🌙'
+    },
+    {
+        id: 'unity-hub',
+        name: 'Unity Hub',
+        url: 'https://unity.com/download',
+        category: 'creation',
+        platform: 'Windows · macOS',
+        description: 'Unity 官方管理工具，支持项目版本管理、Asset Store 集成与团队协作。',
+        tags: ['游戏引擎', '版本管理'],
+        icon: '🧊'
+    },
+    {
+        id: 'unreal-engine',
+        name: 'Unreal Engine Launcher',
+        url: 'https://www.unrealengine.com/download',
+        category: 'creation',
+        platform: 'Windows · macOS',
+        description: '虚幻引擎启动器，提供引擎版本下载、示例项目、Marketplace 与学习资源。',
+        tags: ['虚幻引擎', 'Marketplace'],
+        icon: '🌀'
+    },
+    {
+        id: 'godot',
+        name: 'Godot Engine',
+        url: 'https://godotengine.org/download',
+        category: 'creation',
+        platform: 'Windows · macOS · Linux',
+        description: '轻量开源的 2D/3D 游戏引擎，支持 C#, GDScript 多语言，提供 MIT 许可自由发布。',
+        tags: ['开源', '轻量'],
+        icon: '🐙'
+    },
+    {
+        id: 'blender',
+        name: 'Blender',
+        url: 'https://www.blender.org/download/',
+        category: 'creation',
+        platform: 'Windows · macOS · Linux',
+        description: '功能全面的开源 3D 内容创作套件，覆盖建模、动画、渲染与视频剪辑。',
+        tags: ['3D 建模', '开源'],
+        icon: '🧱'
+    },
+    {
+        id: 'retroarch',
+        name: 'RetroArch',
+        url: 'https://www.retroarch.com/?page=platforms',
+        category: 'emulator',
+        platform: 'Windows · macOS · Linux · Android · iOS',
+        description: '多合一的模拟器前端，内置核心管理与联网对战，支持成就、滤镜与回放功能。',
+        tags: ['多平台', '成就系统'],
+        icon: '🕹️'
+    },
+    {
+        id: 'dolphin',
+        name: 'Dolphin Emulator',
+        url: 'https://dolphin-emu.org/download/',
+        category: 'emulator',
+        platform: 'Windows · macOS · Linux · Android',
+        description: '开源的 Wii / GameCube 模拟器，支持高清画面、联机与各类控制器配置。',
+        tags: ['Wii', 'GameCube'],
+        icon: '🐬'
+    },
+    {
+        id: 'pcsx2',
+        name: 'PCSX2',
+        url: 'https://pcsx2.net/downloads',
+        category: 'emulator',
+        platform: 'Windows · Linux',
+        description: 'PlayStation 2 模拟器，提供画面增强、存档快照与广泛的手柄映射支持。',
+        tags: ['PS2', '高分辨率'],
+        icon: '🎛️'
+    },
+    {
+        id: 'cemu',
+        name: 'Cemu',
+        url: 'https://cemu.info',
+        category: 'emulator',
+        platform: 'Windows · Linux',
+        description: 'Wii U 模拟器，支持高帧率补丁、图形增强与键鼠/手柄自由切换。',
+        tags: ['Wii U', '60FPS'],
+        icon: '🧩'
+    }
+];
+
+const softwareGrid = document.getElementById('softwareGrid');
+const searchInput = document.getElementById('softwareSearch');
+const resultsCount = document.getElementById('softwareResultsCount');
+const filterButtons = Array.from(document.querySelectorAll('.navigation-filters .filter-button'));
+
+let activeFilter = 'all';
+
+const createTag = (label) => {
+    const span = document.createElement('span');
+    span.className = 'software-tag';
+    span.textContent = label;
+    return span;
+};
+
+const buildCard = (item) => {
+    const card = document.createElement('article');
+    card.className = 'software-card';
+    card.setAttribute('role', 'listitem');
+    card.dataset.category = item.category;
+
+    const header = document.createElement('div');
+    header.className = 'software-card__header';
+
+    const icon = document.createElement('span');
+    icon.className = 'software-icon';
+    icon.textContent = item.icon || '🎮';
+    header.appendChild(icon);
+
+    const titleWrap = document.createElement('div');
+    titleWrap.className = 'software-card__title';
+
+    const titleLink = document.createElement('a');
+    titleLink.href = item.url;
+    titleLink.target = '_blank';
+    titleLink.rel = 'noopener';
+    titleLink.className = 'software-name';
+    titleLink.textContent = item.name;
+    titleWrap.appendChild(titleLink);
+
+    const meta = document.createElement('p');
+    meta.className = 'software-meta';
+    meta.textContent = item.platform;
+    titleWrap.appendChild(meta);
+
+    header.appendChild(titleWrap);
+
+    const categoryBadge = document.createElement('span');
+    categoryBadge.className = 'software-category';
+    categoryBadge.textContent = getCategoryLabel(item.category);
+    header.appendChild(categoryBadge);
+
+    card.appendChild(header);
+
+    const desc = document.createElement('p');
+    desc.className = 'software-desc';
+    desc.textContent = item.description;
+    card.appendChild(desc);
+
+    if (Array.isArray(item.tags) && item.tags.length > 0) {
+        const tagWrap = document.createElement('div');
+        tagWrap.className = 'software-tags';
+        item.tags.forEach(tag => tagWrap.appendChild(createTag(tag)));
+        card.appendChild(tagWrap);
+    }
+
+    const link = document.createElement('a');
+    link.href = item.url;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.className = 'software-link';
+    link.textContent = '前往下载 / 官网';
+    card.appendChild(link);
+
+    return card;
+};
+
+const getCategoryLabel = (category) => {
+    switch (category) {
+        case 'platform':
+            return '发行平台';
+        case 'cloud':
+            return '云游戏 / 串流';
+        case 'creation':
+            return '创作工具';
+        case 'emulator':
+            return '模拟器';
+        case 'utility':
+            return '工具 / 管理';
+        default:
+            return '其他';
+    }
+};
+
+const renderSoftware = (items) => {
+    softwareGrid.innerHTML = '';
+
+    if (items.length === 0) {
+        const empty = document.createElement('p');
+        empty.className = 'software-empty';
+        empty.textContent = '未找到匹配的软件，尝试更换关键词或筛选条件。';
+        softwareGrid.appendChild(empty);
+        resultsCount.textContent = '0 款软件';
+        return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    items.forEach(item => fragment.appendChild(buildCard(item)));
+    softwareGrid.appendChild(fragment);
+
+    resultsCount.textContent = `${items.length} 款软件`;
+};
+
+const filterSoftware = () => {
+    const keyword = searchInput.value.trim().toLowerCase();
+
+    const filtered = softwareData.filter(item => {
+        const matchesFilter = activeFilter === 'all' || item.category === activeFilter;
+        if (!matchesFilter) return false;
+
+        if (!keyword) return true;
+
+        const combined = [
+            item.name,
+            item.description,
+            item.platform,
+            ...(item.tags || [])
+        ].join(' ').toLowerCase();
+
+        return combined.includes(keyword);
+    });
+
+    renderSoftware(filtered);
+};
+
+filterButtons.forEach(button => {
+    button.addEventListener('click', () => {
+        const targetFilter = button.dataset.filter;
+        if (activeFilter === targetFilter) return;
+
+        activeFilter = targetFilter;
+        filterButtons.forEach(btn => {
+            const isActive = btn === button;
+            btn.classList.toggle('is-active', isActive);
+            btn.setAttribute('aria-selected', String(isActive));
+        });
+
+        filterSoftware();
+    });
+});
+
+searchInput.addEventListener('input', () => {
+    filterSoftware();
+});
+
+renderSoftware(softwareData);
+filterSoftware();

--- a/game-sites.html
+++ b/game-sites.html
@@ -18,6 +18,7 @@
                 <a href="sprunki.html">Sprunki 专区</a>
                 <a href="zoo-3dcube.html">Zoo 3D Cube</a>
                 <a href="game-sites.html" aria-current="page">游戏站榜单</a>
+                <a href="game-navigation.html">软件导航</a>
                 <a href="scratch-scraper.html">游戏抓取</a>
             </nav>
         </div>

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
                 <a href="sprunki.html">Sprunki 专区</a>
                 <a href="zoo-3dcube.html">Zoo 3D Cube</a>
                 <a href="game-sites.html">游戏站榜单</a>
+                <a href="game-navigation.html">软件导航</a>
                 <a href="scratch-scraper.html">游戏抓取</a>
             </nav>
         </div>

--- a/scratch-scraper.html
+++ b/scratch-scraper.html
@@ -18,6 +18,7 @@
                 <a href="sprunki.html">Sprunki 专区</a>
                 <a href="zoo-3dcube.html">Zoo 3D Cube</a>
                 <a href="game-sites.html">游戏站榜单</a>
+                <a href="game-navigation.html">软件导航</a>
                 <a href="scratch-scraper.html" aria-current="page">游戏抓取</a>
             </nav>
         </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -25,4 +25,9 @@
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
+  <url>
+    <loc>https://youxistudio.com/game-navigation.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>

--- a/sprunki.html
+++ b/sprunki.html
@@ -31,6 +31,7 @@
         <a href="game-detail.html?id=sprunki">Sprunki 详情</a>
         <a href="zoo-3dcube.html">Zoo 3D Cube</a>
         <a href="game-sites.html">游戏站榜单</a>
+        <a href="game-navigation.html">软件导航</a>
         <a href="scratch-scraper.html">游戏抓取</a>
       </nav>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -792,3 +792,204 @@ button {
         font-size: 1.5rem;
     }
 }
+
+.navigation-hero {
+    background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.2), transparent 55%),
+                radial-gradient(circle at top right, rgba(16, 185, 129, 0.22), transparent 60%),
+                linear-gradient(135deg, #1d4ed8, #0f172a);
+    color: #ffffff;
+    padding: 2.75rem 2.5rem;
+    border-radius: var(--radius-lg);
+    box-shadow: 0 28px 45px rgba(15, 23, 42, 0.3);
+    text-align: left;
+    position: relative;
+    overflow: hidden;
+    margin-bottom: 2.75rem;
+}
+
+.navigation-hero::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at bottom right, rgba(255, 255, 255, 0.18), transparent 65%);
+    pointer-events: none;
+}
+
+.navigation-hero h1 {
+    margin-top: 0.4rem;
+    margin-bottom: 0.8rem;
+}
+
+.navigation-hero p {
+    margin: 0;
+    max-width: 620px;
+    color: rgba(248, 250, 252, 0.9);
+}
+
+.navigation-highlights {
+    margin-top: 1.8rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.85rem;
+}
+
+.navigation-highlights span {
+    background: rgba(15, 23, 42, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    padding: 0.45rem 0.85rem;
+    border-radius: 999px;
+    font-size: 0.9rem;
+    backdrop-filter: blur(4px);
+}
+
+.navigation-tools {
+    margin-top: 2.5rem;
+}
+
+.navigation-filters {
+    justify-content: center;
+    gap: 0.75rem;
+}
+
+.software-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.software-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    box-shadow: var(--shadow-soft);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    min-height: 260px;
+}
+
+.software-card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-strong);
+}
+
+.software-card__header {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.9rem;
+}
+
+.software-icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    background: var(--brand-soft);
+    display: grid;
+    place-items: center;
+    font-size: 1.2rem;
+    color: var(--brand);
+}
+
+.software-card__title {
+    flex: 1;
+}
+
+.software-name {
+    font-size: 1.1rem;
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.software-name:hover {
+    color: var(--brand);
+}
+
+.software-meta {
+    margin: 0.25rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.software-category {
+    align-self: flex-start;
+    padding: 0.4rem 0.7rem;
+    border-radius: 10px;
+    background: var(--surface-strong);
+    color: var(--brand);
+    font-weight: 600;
+    font-size: 0.8rem;
+}
+
+.software-desc {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.software-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.software-tag {
+    padding: 0.35rem 0.6rem;
+    background: var(--surface-strong);
+    border-radius: var(--radius-sm);
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+.software-link {
+    margin-top: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: var(--brand);
+    font-weight: 600;
+}
+
+.software-link::after {
+    content: '→';
+    font-size: 1rem;
+    transition: transform 0.2s ease;
+}
+
+.software-link:hover::after {
+    transform: translateX(3px);
+}
+
+.software-empty {
+    grid-column: 1 / -1;
+    padding: 2.5rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    text-align: center;
+    color: var(--text-secondary);
+}
+
+@media (max-width: 900px) {
+    .navigation-hero {
+        padding: 2.25rem 1.75rem;
+    }
+
+    .navigation-filters {
+        justify-content: flex-start;
+    }
+}
+
+@media (max-width: 600px) {
+    .navigation-highlights {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .software-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/zoo-3dcube.html
+++ b/zoo-3dcube.html
@@ -23,6 +23,7 @@
         <a href="sprunki.html">Sprunki 专区</a>
         <a href="game-detail.html?id=zoo-3dcube">游戏详情</a>
         <a href="game-sites.html">游戏站榜单</a>
+        <a href="game-navigation.html">软件导航</a>
         <a href="scratch-scraper.html">游戏抓取</a>
       </nav>
     </div>


### PR DESCRIPTION
## Summary
- create a dedicated software navigation page with hero, search, and filter controls mirroring the pokee.org style guidance
- seed the page with 20+ curated game launchers, creation tools, cloud services, and emulators plus interactive rendering logic
- extend shared navigation and sitemap entries so the new page is discoverable across the site

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e284a079c483219ee41da056324c84