### PR TITLE
Add latest game aggregation dashboard

### DIFF
--- a/game-detail.html
+++ b/game-detail.html
@@ -15,6 +15,7 @@
             <nav class="site-nav" aria-label="主要导航">
                 <a href="index.html#games">返回游戏列表</a>
                 <a href="https://scratch.mit.edu" target="_blank" rel="noopener">Scratch 官网</a>
+                <a href="latest-games.html">最新游戏</a>
                 <a id="anotherHotLink" href="game-detail.html?id=geometry-dash">另一个热门</a>
                 <a href="game-sites.html">游戏站榜单</a>
                 <a href="game-navigation.html">软件导航</a>

--- a/game-navigation.html
+++ b/game-navigation.html
@@ -14,6 +14,7 @@
             <nav class="site-nav" aria-label="主要导航">
                 <a href="index.html#games">全部游戏</a>
                 <a href="https://scratch.mit.edu" target="_blank" rel="noopener">Scratch 官网</a>
+                <a href="latest-games.html">最新游戏</a>
                 <a href="game-detail.html?id=paper-minecraft">热门推荐</a>
                 <a href="sprunki.html">Sprunki 专区</a>
                 <a href="zoo-3dcube.html">Zoo 3D Cube</a>

--- a/game-sites.html
+++ b/game-sites.html
@@ -14,6 +14,7 @@
             <nav class="site-nav" aria-label="主要导航">
                 <a href="index.html#games">全部游戏</a>
                 <a href="https://scratch.mit.edu" target="_blank" rel="noopener">Scratch 官网</a>
+                <a href="latest-games.html">最新游戏</a>
                 <a href="game-detail.html?id=paper-minecraft">热门推荐</a>
                 <a href="sprunki.html">Sprunki 专区</a>
                 <a href="zoo-3dcube.html">Zoo 3D Cube</a>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
             <nav class="site-nav" aria-label="主要导航">
                 <a href="#games">全部游戏</a>
                 <a href="https://scratch.mit.edu" target="_blank" rel="noopener">Scratch 官网</a>
+                <a href="latest-games.html">最新游戏</a>
                 <a href="game-detail.html?id=paper-minecraft">热门推荐</a>
                 <a href="sprunki.html">Sprunki 专区</a>
                 <a href="zoo-3dcube.html">Zoo 3D Cube</a>

--- a/latest-games.html
+++ b/latest-games.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>最新游戏追踪 | Shadowmilk Scratch</title>
+    <meta name="description" content="一站式获取 1Games、CrazyGames、GameMonetize、GameDistribution 与 Scratch 平台的最新游戏名称，支持自定义站点地图与抓取范围。">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header class="site-header">
+        <div class="container header-inner">
+            <a class="logo" href="index.html">Shadowmilk Scratch</a>
+            <nav class="site-nav" aria-label="主要导航">
+                <a href="index.html#games">全部游戏</a>
+                <a href="https://scratch.mit.edu" target="_blank" rel="noopener">Scratch 官网</a>
+                <a href="latest-games.html" aria-current="page">最新游戏</a>
+                <a href="game-detail.html?id=paper-minecraft">热门推荐</a>
+                <a href="sprunki.html">Sprunki 专区</a>
+                <a href="zoo-3dcube.html">Zoo 3D Cube</a>
+                <a href="game-sites.html">游戏站榜单</a>
+                <a href="game-navigation.html">软件导航</a>
+                <a href="scratch-scraper.html">游戏抓取</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="page" id="latest-games">
+        <div class="container">
+            <section class="latest-hero" aria-labelledby="latest-hero-title">
+                <p class="eyebrow">GLOBAL GAME WATCHLIST</p>
+                <h1 id="latest-hero-title">实时追踪多平台最新游戏</h1>
+                <p>我们为 1Games.io、CrazyGames、GameMonetize、GameDistribution 与 Scratch 的最新作品提供统一的监测面板。你可以自定义站点地图地址、抓取数量，并支持手动刷新或对比站点地图版本。</p>
+                <ul class="latest-hero__highlights" aria-label="功能亮点">
+                    <li>✔ 统一主菜单，快速回到站内其它页面</li>
+                    <li>✔ 默认接入 5 大平台站点地图</li>
+                    <li>✔ 支持自定义抓取 URL 与数量</li>
+                    <li>✔ 自动处理跨域（基于 r.jina.ai 代理）</li>
+                </ul>
+            </section>
+
+            <section class="latest-controls" aria-labelledby="latest-controls-title">
+                <div class="controls-header">
+                    <div>
+                        <h2 id="latest-controls-title">数据源与抓取设置</h2>
+                        <p class="controls-subtitle">可以按照需要启用或停用数据源，修改站点地图 URL，必要时也可在刷新前对比站点地图。</p>
+                    </div>
+                    <button type="button" id="refreshButton" class="primary-button">立即刷新</button>
+                </div>
+                <p class="proxy-hint">提示：页面默认通过 <code>https://r.jina.ai/</code> 代理处理跨域访问。如果目标站点不允许该代理，可自行替换为其他可用的代理服务。</p>
+                <div id="sourcesGrid" class="sources-grid" aria-live="polite"></div>
+            </section>
+
+            <section class="latest-results" aria-labelledby="latest-results-title" aria-live="polite">
+                <div class="results-header">
+                    <h2 id="latest-results-title">最新游戏结果</h2>
+                    <p id="resultsSummary" class="results-summary">尚未进行抓取。</p>
+                </div>
+                <div id="resultsContainer" class="results-grid"></div>
+            </section>
+        </div>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container footer-inner">
+            <p>Shadowmilk Scratch Arcade · 一起守护 Scratch 的创意与乐趣</p>
+            <div class="footer-links">
+                <a href="https://scratch.mit.edu/parents" target="_blank" rel="noopener">家长指引</a>
+                <a href="https://scratch.mit.edu/community_guidelines" target="_blank" rel="noopener">社区守则</a>
+                <a href="mailto:hello@shadowmilk.org">联系站长</a>
+            </div>
+        </div>
+    </footer>
+
+    <script src="latest-games.js"></script>
+</body>
+</html>

--- a/latest-games.js
+++ b/latest-games.js
@@ -1,0 +1,362 @@
+(function () {
+    const sources = [
+        {
+            id: '1games',
+            name: '1Games.io',
+            description: '默认使用 1Games 的总站点地图，可按需替换为更具体的分类地图。',
+            url: 'https://1games.io/sitemap.xml',
+            format: 'xml-sitemap',
+            limit: 12,
+            filter: (loc) => /\/game\//.test(loc) || /1games\.io\//.test(loc)
+        },
+        {
+            id: 'crazygames',
+            name: 'CrazyGames',
+            description: 'CrazyGames 官方 sitemap，建议保留 https 协议以获得最新的游戏列表。',
+            url: 'https://www.crazygames.com/sitemap.xml',
+            format: 'xml-sitemap',
+            limit: 12,
+            filter: (loc) => /\/game\//.test(loc)
+        },
+        {
+            id: 'gamemonetize',
+            name: 'GameMonetize',
+            description: 'GameMonetize 按字母拆分 sitemap，可自定义为具体分段，例如 sitemap-A.xml。',
+            url: 'https://gamemonetize.com/sitemap.xml',
+            format: 'xml-sitemap',
+            limit: 12,
+            filter: (loc) => /gamemonetize\.com\//.test(loc)
+        },
+        {
+            id: 'gamedistribution',
+            name: 'GameDistribution',
+            description: 'GameDistribution 使用 CDN sitemap，可填写 sitemap-index 或具体的 sitemap-0.xml。',
+            url: 'https://sitemap.cdn.gamedistribution.com/sitemap-index.xml',
+            format: 'xml-sitemap',
+            limit: 12,
+            filter: (loc) => /gamedistribution\.com\//.test(loc)
+        },
+        {
+            id: 'scratch',
+            name: 'Scratch',
+            description: '默认抓取 Scratch 官方 sitemap，可搭配项目 API 获取更丰富的信息。',
+            url: 'https://scratch.mit.edu/sitemap.xml',
+            format: 'xml-sitemap',
+            limit: 12,
+            filter: (loc) => /scratch\.mit\.edu\/projects\//.test(loc)
+        }
+    ];
+
+    const state = new Map();
+
+    const sourcesGrid = document.getElementById('sourcesGrid');
+    const refreshButton = document.getElementById('refreshButton');
+    const resultsSummary = document.getElementById('resultsSummary');
+    const resultsContainer = document.getElementById('resultsContainer');
+
+    if (!sourcesGrid || !refreshButton) {
+        return;
+    }
+
+    function ensureProxy(url) {
+        if (!url) return '';
+        if (url.startsWith('https://r.jina.ai/')) {
+            return url;
+        }
+        const sanitized = url.replace(/^https?:\/\//, '');
+        const isHttps = /^https:/.test(url);
+        return `https://r.jina.ai/${isHttps ? 'https://' : 'http://'}${sanitized}`;
+    }
+
+    function humanizeSlug(url) {
+        if (!url) {
+            return '未知游戏';
+        }
+        try {
+            const { pathname } = new URL(url);
+            const segment = pathname.split('/').filter(Boolean).pop() || pathname;
+            return segment
+                .replace(/[?#].*$/, '')
+                .replace(/[-_]+/g, ' ')
+                .replace(/\b\w/g, (match) => match.toUpperCase());
+        } catch (error) {
+            return url;
+        }
+    }
+
+    function formatDate(value) {
+        if (!value) return '';
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return '';
+        }
+        return new Intl.DateTimeFormat('zh-Hans', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit'
+        }).format(date);
+    }
+
+    function parseSitemap(xmlText, source) {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(xmlText, 'application/xml');
+        const errors = doc.getElementsByTagName('parsererror');
+        if (errors.length) {
+            throw new Error('站点地图解析失败');
+        }
+
+        const entries = [];
+        const urlNodes = Array.from(doc.getElementsByTagName('url'));
+        if (urlNodes.length) {
+            urlNodes.forEach((node) => {
+                const locNode = node.getElementsByTagName('loc')[0];
+                if (!locNode) return;
+                const loc = locNode.textContent?.trim();
+                if (!loc) return;
+                if (typeof source.filter === 'function' && !source.filter(loc)) {
+                    return;
+                }
+                const lastmodNode = node.getElementsByTagName('lastmod')[0];
+                entries.push({
+                    url: loc,
+                    title: humanizeSlug(loc),
+                    lastmod: lastmodNode?.textContent?.trim() || ''
+                });
+            });
+        }
+
+        if (!entries.length) {
+            const sitemapNodes = Array.from(doc.getElementsByTagName('sitemap'));
+            sitemapNodes.forEach((node) => {
+                const locNode = node.getElementsByTagName('loc')[0];
+                if (!locNode) return;
+                const loc = locNode.textContent?.trim();
+                if (!loc) return;
+                entries.push({
+                    url: loc,
+                    title: humanizeSlug(loc),
+                    lastmod: node.getElementsByTagName('lastmod')[0]?.textContent?.trim() || ''
+                });
+            });
+        }
+
+        return entries;
+    }
+
+    async function fetchSource(source) {
+        const targetUrl = state.get(source.id)?.url || source.url;
+        if (!targetUrl) {
+            throw new Error('未设置有效的站点地图地址');
+        }
+        const response = await fetch(ensureProxy(targetUrl), {
+            headers: {
+                'Accept': 'application/xml,text/xml,text/plain,*/*'
+            }
+        });
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+        const text = await response.text();
+        if (!text.trim()) {
+            throw new Error('站点地图返回为空');
+        }
+        const entries = parseSitemap(text, source);
+        if (!entries.length) {
+            throw new Error('未在站点地图中找到可用条目');
+        }
+        const limit = state.get(source.id)?.limit ?? source.limit ?? 10;
+        return entries.slice(0, Math.max(1, Number(limit) || 10));
+    }
+
+    function createSourceCard(source) {
+        const wrapper = document.createElement('article');
+        wrapper.className = 'source-card';
+        wrapper.dataset.sourceId = source.id;
+
+        const header = document.createElement('header');
+        header.className = 'source-card__header';
+
+        const label = document.createElement('label');
+        label.className = 'source-card__toggle';
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = true;
+        checkbox.setAttribute('aria-label', `启用 ${source.name} 数据源`);
+        const nameSpan = document.createElement('span');
+        nameSpan.textContent = source.name;
+        label.append(checkbox, nameSpan);
+
+        const status = document.createElement('span');
+        status.className = 'source-status';
+        status.dataset.status = 'idle';
+        status.dataset.sourceStatusFor = source.id;
+        status.textContent = '等待抓取';
+
+        header.append(label, status);
+
+        const body = document.createElement('div');
+        body.className = 'source-card__body';
+
+        const description = document.createElement('p');
+        description.className = 'source-card__description';
+        description.textContent = source.description;
+
+        const urlLabel = document.createElement('label');
+        urlLabel.className = 'source-card__field';
+        urlLabel.textContent = '站点地图 / 数据源 URL';
+        const urlInput = document.createElement('input');
+        urlInput.type = 'url';
+        urlInput.value = source.url;
+        urlInput.placeholder = 'https://example.com/sitemap.xml';
+        urlInput.autocomplete = 'off';
+        urlInput.required = true;
+        urlInput.addEventListener('change', () => {
+            const data = state.get(source.id) || {};
+            data.url = urlInput.value.trim();
+            state.set(source.id, data);
+        });
+        urlLabel.appendChild(urlInput);
+
+        const limitLabel = document.createElement('label');
+        limitLabel.className = 'source-card__field source-card__field--inline';
+        limitLabel.textContent = '抓取条数';
+        const limitInput = document.createElement('input');
+        limitInput.type = 'number';
+        limitInput.min = '1';
+        limitInput.max = '100';
+        limitInput.value = String(source.limit ?? 12);
+        limitInput.addEventListener('change', () => {
+            const value = Math.max(1, Math.min(100, Number(limitInput.value) || 10));
+            limitInput.value = String(value);
+            const data = state.get(source.id) || {};
+            data.limit = value;
+            state.set(source.id, data);
+        });
+        limitLabel.appendChild(limitInput);
+
+        body.append(description, urlLabel, limitLabel);
+
+        wrapper.append(header, body);
+
+        state.set(source.id, {
+            url: source.url,
+            limit: source.limit,
+            enabled: true
+        });
+
+        checkbox.addEventListener('change', () => {
+            const data = state.get(source.id) || {};
+            data.enabled = checkbox.checked;
+            state.set(source.id, data);
+            wrapper.classList.toggle('source-card--disabled', !checkbox.checked);
+            if (!checkbox.checked) {
+                setStatus(source.id, 'idle', '已停用');
+            } else {
+                setStatus(source.id, 'idle', '等待抓取');
+            }
+        });
+
+        return wrapper;
+    }
+
+    function setStatus(id, status, message) {
+        const badge = sourcesGrid.querySelector(`[data-source-status-for="${id}"]`);
+        if (!badge) return;
+        badge.dataset.status = status;
+        badge.textContent = message;
+    }
+
+    function renderResults(results) {
+        resultsContainer.innerHTML = '';
+        if (!results.length) {
+            const empty = document.createElement('div');
+            empty.className = 'empty-state';
+            empty.textContent = '没有获取到任何结果，请检查站点地图设置或更换代理服务。';
+            resultsContainer.appendChild(empty);
+            resultsSummary.textContent = '未成功获取任何平台的游戏列表。';
+            return;
+        }
+
+        const total = results.reduce((sum, group) => sum + group.items.length, 0);
+        resultsSummary.textContent = `成功获取 ${results.length} 个平台，共 ${total} 条游戏记录。`;
+
+        results.forEach((group) => {
+            const section = document.createElement('section');
+            section.className = 'results-block';
+
+            const heading = document.createElement('header');
+            heading.className = 'results-block__header';
+            const title = document.createElement('h3');
+            title.textContent = group.name;
+            const count = document.createElement('span');
+            count.className = 'results-block__count';
+            count.textContent = `${group.items.length} 条`;
+            heading.append(title, count);
+
+            const list = document.createElement('ol');
+            list.className = 'results-block__list';
+
+            group.items.forEach((item) => {
+                const li = document.createElement('li');
+                const link = document.createElement('a');
+                link.href = item.url;
+                link.target = '_blank';
+                link.rel = 'noopener';
+                link.textContent = item.title || item.url;
+                const meta = document.createElement('span');
+                meta.className = 'results-block__meta';
+                const dateText = formatDate(item.lastmod);
+                meta.textContent = dateText ? `更新：${dateText}` : '无更新时间信息';
+                li.append(link, meta);
+                list.appendChild(li);
+            });
+
+            section.append(heading, list);
+            resultsContainer.appendChild(section);
+        });
+    }
+
+    async function handleRefresh() {
+        const enabledSources = sources.filter((source) => {
+            const data = state.get(source.id);
+            return data?.enabled !== false;
+        });
+
+        if (!enabledSources.length) {
+            resultsSummary.textContent = '请至少启用一个数据源再进行刷新。';
+            resultsContainer.innerHTML = '';
+            return;
+        }
+
+        refreshButton.disabled = true;
+        refreshButton.textContent = '抓取中...';
+
+        const promises = enabledSources.map(async (source) => {
+            setStatus(source.id, 'loading', '抓取中...');
+            try {
+                const items = await fetchSource(source);
+                setStatus(source.id, 'success', `成功 ${items.length} 条`);
+                return { id: source.id, name: source.name, items };
+            } catch (error) {
+                console.error(error);
+                setStatus(source.id, 'error', error.message || '抓取失败');
+                return null;
+            }
+        });
+
+        const settled = await Promise.all(promises);
+        const validResults = settled.filter(Boolean);
+        renderResults(validResults);
+
+        refreshButton.disabled = false;
+        refreshButton.textContent = '立即刷新';
+    }
+
+    sources.forEach((source) => {
+        const card = createSourceCard(source);
+        sourcesGrid.appendChild(card);
+    });
+
+    refreshButton.addEventListener('click', handleRefresh);
+    handleRefresh();
+})();

--- a/scratch-scraper.html
+++ b/scratch-scraper.html
@@ -14,6 +14,7 @@
             <nav class="site-nav" aria-label="主要导航">
                 <a href="index.html#games">全部游戏</a>
                 <a href="https://scratch.mit.edu" target="_blank" rel="noopener">Scratch 官网</a>
+                <a href="latest-games.html">最新游戏</a>
                 <a href="game-detail.html?id=paper-minecraft">热门推荐</a>
                 <a href="sprunki.html">Sprunki 专区</a>
                 <a href="zoo-3dcube.html">Zoo 3D Cube</a>

--- a/sprunki.html
+++ b/sprunki.html
@@ -29,6 +29,7 @@
       <nav class="site-nav" aria-label="主要导航">
         <a href="index.html">首页</a>
         <a href="game-detail.html?id=sprunki">Sprunki 详情</a>
+        <a href="latest-games.html">最新游戏</a>
         <a href="zoo-3dcube.html">Zoo 3D Cube</a>
         <a href="game-sites.html">游戏站榜单</a>
         <a href="game-navigation.html">软件导航</a>

--- a/styles.css
+++ b/styles.css
@@ -973,6 +973,302 @@ button {
     color: var(--text-secondary);
 }
 
+/* 最新游戏追踪页面 */
+#latest-games {
+    display: flex;
+    flex-direction: column;
+    gap: 3rem;
+}
+
+.latest-hero {
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(14, 116, 144, 0.08));
+    border: 1px solid rgba(37, 99, 235, 0.14);
+    border-radius: var(--radius-lg);
+    padding: 3.5rem;
+    box-shadow: var(--shadow-soft);
+}
+
+.latest-hero__highlights {
+    list-style: none;
+    margin: 2rem 0 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.75rem 1.5rem;
+    color: var(--text-secondary);
+    font-weight: 600;
+}
+
+.latest-controls {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 2.5rem;
+    box-shadow: var(--shadow-soft);
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+}
+
+.controls-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1.5rem;
+}
+
+.controls-header h2 {
+    margin: 0;
+}
+
+.controls-subtitle {
+    margin: 0.35rem 0 0;
+    color: var(--text-secondary);
+}
+
+.proxy-hint {
+    margin: 0;
+    padding: 0.875rem 1rem;
+    background: rgba(15, 23, 42, 0.04);
+    border-radius: var(--radius-md);
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
+.proxy-hint code {
+    background: rgba(15, 23, 42, 0.08);
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+    font-family: 'Fira Code', monospace;
+    font-size: 0.85rem;
+}
+
+.sources-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.source-card {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: 1.5rem;
+    background: var(--surface-strong);
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.source-card:hover {
+    border-color: rgba(37, 99, 235, 0.35);
+    box-shadow: 0 18px 30px rgba(15, 23, 42, 0.08);
+    transform: translateY(-2px);
+}
+
+.source-card--disabled {
+    opacity: 0.6;
+}
+
+.source-card__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.source-card__toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    font-weight: 600;
+}
+
+.source-card__toggle input {
+    width: 1.15rem;
+    height: 1.15rem;
+}
+
+.source-card__description {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.source-card__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.source-card__field input {
+    font: inherit;
+    padding: 0.6rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.source-card__field input:focus {
+    border-color: rgba(37, 99, 235, 0.65);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.source-card__field--inline {
+    max-width: 120px;
+}
+
+.source-status {
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 0.25rem 0.55rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.05);
+    color: var(--text-secondary);
+    white-space: nowrap;
+}
+
+.source-status[data-status="loading"] {
+    background: rgba(37, 99, 235, 0.15);
+    color: var(--brand);
+}
+
+.source-status[data-status="success"] {
+    background: rgba(22, 163, 74, 0.16);
+    color: #15803d;
+}
+
+.source-status[data-status="error"] {
+    background: rgba(220, 38, 38, 0.16);
+    color: #b91c1c;
+}
+
+.latest-results {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 2.5rem;
+    box-shadow: var(--shadow-soft);
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.results-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.results-header h2 {
+    margin: 0;
+}
+
+.results-summary {
+    margin: 0;
+    color: var(--text-secondary);
+}
+
+.results-grid {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.results-block {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: 1.5rem;
+    background: var(--surface-strong);
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.results-block__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.results-block__header h3 {
+    margin: 0;
+}
+
+.results-block__count {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    background: rgba(15, 23, 42, 0.05);
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+}
+
+.results-block__list {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.results-block__list li {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.results-block__list a {
+    color: var(--brand);
+    font-weight: 600;
+    word-break: break-all;
+}
+
+.results-block__list a:hover {
+    text-decoration: underline;
+}
+
+.results-block__meta {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+@media (max-width: 900px) {
+    .latest-hero {
+        padding: 2.5rem;
+    }
+
+    .latest-controls,
+    .latest-results {
+        padding: 2rem;
+    }
+
+    .controls-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .controls-header > button {
+        align-self: flex-start;
+    }
+}
+
+@media (max-width: 600px) {
+    .latest-hero {
+        padding: 1.75rem;
+    }
+
+    .latest-hero__highlights {
+        grid-template-columns: 1fr;
+    }
+
+    .latest-controls,
+    .latest-results {
+        padding: 1.5rem;
+    }
+}
+
 @media (max-width: 900px) {
     .navigation-hero {
         padding: 2.25rem 1.75rem;

--- a/zoo-3dcube.html
+++ b/zoo-3dcube.html
@@ -21,6 +21,7 @@
       <nav class="site-nav" aria-label="主要导航">
         <a href="index.html">首页</a>
         <a href="sprunki.html">Sprunki 专区</a>
+        <a href="latest-games.html">最新游戏</a>
         <a href="game-detail.html?id=zoo-3dcube">游戏详情</a>
         <a href="game-sites.html">游戏站榜单</a>
         <a href="game-navigation.html">软件导航</a>


### PR DESCRIPTION
## Summary
- add a latest-games page with a dashboard UI for monitoring multiple game platforms
- implement the client-side fetcher to read sitemap feeds, handle proxying, and render the newest titles
- extend shared styles and navigation links to surface the new page across the site

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e332fc53008321b9b966fba1502418