### PR TITLE
Add Mancala single-page game site

### DIFF
--- a/games/Mancala/index.html
+++ b/games/Mancala/index.html
@@ -1,0 +1,353 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mancala Online | Youxi Studio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg-gradient: linear-gradient(135deg, #1f3c88, #2e8bc0 55%, #a2d5f2);
+        --card-bg: rgba(255, 255, 255, 0.88);
+        --card-border: rgba(255, 255, 255, 0.25);
+        --text-color: #0f172a;
+        --muted-text: #334155;
+        --accent-color: #f97316;
+        --pill-bg: rgba(15, 23, 42, 0.85);
+        --pill-text: #f8fafc;
+        font-family: "Poppins", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: var(--bg-gradient);
+        color: var(--text-color);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 48px 24px;
+      }
+
+      main {
+        width: min(1200px, 100%);
+        background: var(--card-bg);
+        border-radius: 28px;
+        padding: 48px;
+        box-shadow: 0 30px 70px rgba(15, 23, 42, 0.25);
+        border: 1px solid var(--card-border);
+        backdrop-filter: blur(16px);
+      }
+
+      header {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 20px;
+        margin-bottom: 32px;
+      }
+
+      .game-logo {
+        flex-shrink: 0;
+        width: 88px;
+        height: 88px;
+        border-radius: 24px;
+        background: radial-gradient(circle at 30% 30%, #fde68a, #f59e0b 65%, #b45309);
+        display: grid;
+        place-items: center;
+        color: #1f2937;
+        font-size: 42px;
+        font-weight: 700;
+        letter-spacing: 1px;
+      }
+
+      .title-block {
+        flex: 1;
+        min-width: 250px;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(2rem, 3vw + 1rem, 3.25rem);
+        line-height: 1.1;
+        color: #111827;
+      }
+
+      .tagline {
+        margin: 12px 0 0;
+        font-size: 1.1rem;
+        color: var(--muted-text);
+        max-width: 48ch;
+      }
+
+      .badge-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        margin-top: 16px;
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        background: var(--pill-bg);
+        color: var(--pill-text);
+        padding: 8px 14px;
+        border-radius: 999px;
+        font-size: 0.9rem;
+        letter-spacing: 0.02em;
+      }
+
+      .layout {
+        display: grid;
+        grid-template-columns: repeat(12, 1fr);
+        gap: 32px;
+      }
+
+      .game-area {
+        grid-column: span 7;
+        background: #0f172a;
+        padding: 20px;
+        border-radius: 22px;
+        box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+      }
+
+      iframe {
+        width: 100%;
+        aspect-ratio: 3 / 2;
+        border: none;
+        border-radius: 16px;
+        background: #000;
+      }
+
+      .info-panel {
+        grid-column: span 5;
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+      }
+
+      section {
+        background: rgba(255, 255, 255, 0.85);
+        border-radius: 18px;
+        padding: 24px;
+        border: 1px solid rgba(226, 232, 240, 0.8);
+        box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+      }
+
+      section h2 {
+        margin-top: 0;
+        font-size: 1.4rem;
+        color: #0f172a;
+      }
+
+      section p,
+      section li {
+        margin: 0;
+        color: #1f2937;
+        line-height: 1.65;
+        font-size: 1rem;
+      }
+
+      ul {
+        padding-left: 20px;
+        margin: 12px 0 0;
+      }
+
+      .tips-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 16px;
+        margin-top: 16px;
+      }
+
+      .tip-card {
+        background: rgba(15, 23, 42, 0.9);
+        color: #f8fafc;
+        padding: 18px;
+        border-radius: 16px;
+        font-size: 0.95rem;
+        line-height: 1.5;
+      }
+
+      .cta {
+        background: linear-gradient(135deg, #f97316, #ea580c);
+        color: #fff7ed;
+        text-align: center;
+        padding: 24px;
+        border-radius: 18px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        box-shadow: 0 18px 36px rgba(234, 88, 12, 0.35);
+      }
+
+      .cta strong {
+        font-size: 1.3rem;
+        letter-spacing: 0.03em;
+      }
+
+      .cta a {
+        color: inherit;
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-decoration-color: rgba(255, 255, 255, 0.6);
+        font-weight: 600;
+      }
+
+      @media (max-width: 960px) {
+        body {
+          padding: 32px 16px;
+        }
+
+        main {
+          padding: 32px 24px;
+        }
+
+        .layout {
+          grid-template-columns: 1fr;
+        }
+
+        .game-area,
+        .info-panel {
+          grid-column: auto;
+        }
+
+        iframe {
+          aspect-ratio: 16 / 10;
+        }
+      }
+
+      @media (max-width: 600px) {
+        header {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        body {
+          padding: 24px 12px;
+        }
+
+        main {
+          padding: 24px 16px;
+        }
+
+        .game-logo {
+          width: 72px;
+          height: 72px;
+          font-size: 32px;
+        }
+
+        section,
+        .cta {
+          padding: 20px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="game-logo">M</div>
+        <div class="title-block">
+          <h1>Mancala: Capture the Board</h1>
+          <p class="tagline">
+            Dive into the timeless strategy classic. Master the sowing rhythm, outsmart your
+            rival, and become the Mancala champion.
+          </p>
+          <div class="badge-row">
+            <span class="badge">✨ Gorgeous 3D experience</span>
+            <span class="badge">🧠 Smart AI opponents</span>
+            <span class="badge">🎮 Free to play</span>
+          </div>
+        </div>
+      </header>
+
+      <div class="layout">
+        <div class="game-area" aria-label="Mancala game iframe">
+          <iframe
+            src="https://html5.gamedistribution.com/a2f973472a0f48668039ed366e2a26e8/?gd_sdk_referrer_url=https://www.example.com/games/{game-path}"
+            width="900"
+            height="600"
+            scrolling="no"
+            frameborder="0"
+            title="Play Mancala online"
+            allowfullscreen
+          ></iframe>
+        </div>
+
+        <div class="info-panel">
+          <section aria-labelledby="objective">
+            <h2 id="objective">🎯 Objective</h2>
+            <p>
+              Collect more stones in your store than your opponent by the end of the match to
+              claim victory.
+            </p>
+          </section>
+
+          <section aria-labelledby="setup">
+            <h2 id="setup">🧩 Game Setup</h2>
+            <ul>
+              <li>The board has two rows of six pits each.</li>
+              <li>Each small pit starts with four stones.</li>
+              <li>The large pits (stores) at each end belong to the players.</li>
+              <li>You control the six pits on your side and the store on your right.</li>
+            </ul>
+          </section>
+
+          <section aria-labelledby="gameplay">
+            <h2 id="gameplay">🔄 Gameplay</h2>
+            <ul>
+              <li>Pick up all stones from one of your pits on your turn.</li>
+              <li>Move counterclockwise, dropping one stone into each pit as you go.</li>
+              <li>Skip your opponent’s store, but drop stones into your own store.</li>
+              <li>If your last stone lands in your store, enjoy an extra turn.</li>
+              <li>
+                Land in an empty pit on your side to capture those stones and the opposite pit.
+              </li>
+            </ul>
+          </section>
+
+          <section aria-labelledby="endgame">
+            <h2 id="endgame">🛑 Game End</h2>
+            <ul>
+              <li>The game ends when one side’s six pits are empty.</li>
+              <li>Collect remaining stones on your side into your store.</li>
+              <li>The player with the most stones in their store wins.</li>
+            </ul>
+          </section>
+        </div>
+      </div>
+
+      <section aria-labelledby="tips" style="margin-top: 32px">
+        <h2 id="tips">💡 Tips for Winning</h2>
+        <div class="tips-grid">
+          <div class="tip-card">Try to end your turn in your store to chain extra moves.</div>
+          <div class="tip-card">Stay alert to block your opponent’s capture attempts.</div>
+          <div class="tip-card">Plan ahead—sometimes patience leads to bigger rewards.</div>
+        </div>
+      </section>
+
+      <div class="cta" role="complementary" style="margin-top: 32px">
+        <strong>🎮 Ready for the Ultimate Mancala Challenge?</strong>
+        <span>
+          Experience this classic game in full 3D with stunning visuals, smart AI, and endless
+          strategy fun.
+        </span>
+        <a href="https://mancala.online" target="_blank" rel="noopener">👉 Play free at Mancala.online</a>
+      </div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated Mancala game page under games/Mancala
- embed the hosted Mancala game in an iframe alongside rule summaries and tips
- style the page with responsive, polished presentation and a prominent external call-to-action

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5cefdae148321bbedfc96e9a4e765