### PR TITLE
Add embedded iframe game section to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
                 <a href="sprunki.html">Sprunki 专区</a>
                 <a href="zoo-3dcube.html">Zoo 3D Cube</a>
                 <a href="game-sites.html">游戏站榜单</a>
+                <a href="#iframe-games">IFRAME 游戏</a>
                 <a href="game-navigation.html">软件导航</a>
                 <a href="scratch-scraper.html">游戏抓取</a>
             </nav>
@@ -60,6 +61,76 @@
                     <button type="button" class="filter-button" data-filter="platformer" role="tab" aria-selected="false">平台跳跃</button>
                     <button type="button" class="filter-button" data-filter="puzzle" role="tab" aria-selected="false">益智</button>
                     <button type="button" class="filter-button" data-filter="creative" role="tab" aria-selected="false">创意</button>
+                </div>
+            </section>
+
+            <section class="iframe-games" id="iframe-games" aria-labelledby="iframeGamesHeading">
+                <div class="iframe-games__header">
+                    <p class="eyebrow">EMBEDDED GAME HUB</p>
+                    <h2 id="iframeGamesHeading">直接在站内体验热门游戏平台</h2>
+                    <p>我们精选了几大海外 HTML5 游戏站点，通过 IFRAME 方式嵌入，方便你随时切换试玩。</p>
+                </div>
+                <div class="iframe-games__grid">
+                    <article class="iframe-card">
+                        <header class="iframe-card__header">
+                            <h3>1Games.io</h3>
+                            <p>主打轻量街机与益智小游戏，更新频率快，适合快速上手体验。</p>
+                        </header>
+                        <div class="iframe-wrapper">
+                            <iframe src="https://1games.io" title="1Games.io 游戏列表" loading="lazy" referrerpolicy="no-referrer" allowfullscreen></iframe>
+                        </div>
+                        <div class="iframe-card__actions">
+                            <a class="primary-button" href="https://1games.io" target="_blank" rel="noopener">访问 1Games.io</a>
+                        </div>
+                    </article>
+                    <article class="iframe-card">
+                        <header class="iframe-card__header">
+                            <h3>CrazyGames</h3>
+                            <p>全球知名的 HTML5 游戏聚合站，涵盖赛车、射击、休闲等多种类型。</p>
+                        </header>
+                        <div class="iframe-wrapper">
+                            <iframe src="https://www.crazygames.com" title="CrazyGames 游戏库" loading="lazy" referrerpolicy="no-referrer" allowfullscreen></iframe>
+                        </div>
+                        <div class="iframe-card__actions">
+                            <a class="primary-button" href="https://www.crazygames.com" target="_blank" rel="noopener">访问 CrazyGames</a>
+                        </div>
+                    </article>
+                    <article class="iframe-card">
+                        <header class="iframe-card__header">
+                            <h3>GameMonetize</h3>
+                            <p>提供大量可嵌入的网页小游戏资源，支持多种休闲玩法。</p>
+                        </header>
+                        <div class="iframe-wrapper">
+                            <iframe src="https://gamemonetize.com" title="GameMonetize 游戏库" loading="lazy" referrerpolicy="no-referrer" allowfullscreen></iframe>
+                        </div>
+                        <div class="iframe-card__actions">
+                            <a class="primary-button" href="https://gamemonetize.com" target="_blank" rel="noopener">访问 GameMonetize</a>
+                        </div>
+                    </article>
+                    <article class="iframe-card">
+                        <header class="iframe-card__header">
+                            <h3>GameDistribution</h3>
+                            <p>知名发行商旗下的 HTML5 游戏目录，拥有大量优质原生手游移植。</p>
+                        </header>
+                        <div class="iframe-wrapper">
+                            <iframe src="https://gamedistribution.com" title="GameDistribution 游戏库" loading="lazy" referrerpolicy="no-referrer" allowfullscreen></iframe>
+                        </div>
+                        <div class="iframe-card__actions">
+                            <a class="primary-button" href="https://gamedistribution.com" target="_blank" rel="noopener">访问 GameDistribution</a>
+                        </div>
+                    </article>
+                    <article class="iframe-card">
+                        <header class="iframe-card__header">
+                            <h3>Scratch 官网</h3>
+                            <p>直接浏览 Scratch 官方网站，查看更多创意作品与社区活动。</p>
+                        </header>
+                        <div class="iframe-wrapper">
+                            <iframe src="https://scratch.mit.edu" title="Scratch 官网" loading="lazy" referrerpolicy="no-referrer" allowfullscreen></iframe>
+                        </div>
+                        <div class="iframe-card__actions">
+                            <a class="primary-button" href="https://scratch.mit.edu" target="_blank" rel="noopener">访问 Scratch 官网</a>
+                        </div>
+                    </article>
                 </div>
             </section>
 

--- a/styles.css
+++ b/styles.css
@@ -149,6 +149,85 @@ button {
     box-shadow: var(--shadow-soft);
 }
 
+.iframe-games {
+    background: linear-gradient(180deg, rgba(37, 99, 235, 0.08), rgba(37, 99, 235, 0));
+    border: 1px solid rgba(37, 99, 235, 0.16);
+    border-radius: calc(var(--radius-lg) + 8px);
+    padding: 2.4rem;
+    margin-bottom: 3rem;
+    box-shadow: 0 35px 60px rgba(37, 99, 235, 0.12);
+}
+
+.iframe-games__header {
+    text-align: center;
+    max-width: 720px;
+    margin: 0 auto 2rem;
+}
+
+.iframe-games__header h2 {
+    margin: 0.35rem 0 0.75rem;
+    font-size: clamp(1.85rem, 4vw, 2.35rem);
+}
+
+.iframe-games__header p {
+    color: var(--text-secondary);
+    margin: 0;
+}
+
+.iframe-games__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.8rem;
+}
+
+.iframe-card {
+    background: var(--surface);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    box-shadow: var(--shadow-soft);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    backdrop-filter: blur(4px);
+}
+
+.iframe-card__header {
+    padding: 1.4rem 1.6rem 0.9rem;
+}
+
+.iframe-card__header h3 {
+    margin: 0 0 0.5rem;
+    font-size: 1.25rem;
+}
+
+.iframe-card__header p {
+    margin: 0;
+    color: var(--text-secondary);
+    line-height: 1.55;
+}
+
+.iframe-wrapper {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+    background: #0f172a;
+    overflow: hidden;
+}
+
+.iframe-wrapper iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+}
+
+.iframe-card__actions {
+    padding: 1rem 1.6rem 1.5rem;
+    display: flex;
+    justify-content: flex-end;
+}
+
 .search-row {
     display: flex;
     flex-wrap: wrap;
@@ -350,6 +429,10 @@ button {
     .page {
         padding-top: 2rem;
     }
+
+    .iframe-games {
+        padding: 2rem 1.5rem;
+    }
 }
 
 @media (max-width: 720px) {
@@ -370,6 +453,10 @@ button {
     .play-button {
         width: 100%;
         text-align: center;
+    }
+
+    .iframe-card__actions {
+        justify-content: center;
     }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated iframe games section on the homepage that embeds popular HTML5 portals
- style the new section with responsive cards and gradient container to match the design reference
- extend the navigation with an anchor link for quick access to the iframe area

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e62693ac90832183ce610823fcfba5